### PR TITLE
DM-5121: "Add multiple-filter capabilities to `validate_drp`"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-A set of utilities to run the processCcd task on some 
+Validate an LSST DM processCcd.py output repository
+against a set of LSST Science Requirements Document Key Performance Metrics.
+
+This package also includes examples that run processCcd task on some 
 CFHT data and DECam data
 and validate the astrometric and photometric repeatability of the results.
 
@@ -126,21 +129,21 @@ Note that the example validation test selects several of the CCDs and will fail 
 
 Files of Interest:
 ------------------
+* `bin.src/validateDrp.py`  : Analyze output data produced by processCcd.py
+* `config/cfhtConfig.py`  : empty config overrides for Cfht.  Edit to easily include config parameters in the examples.
+* `config/decamConfig.py` : empty config overrides for Decam.  Edit to easily include config parameters in the examples.
 * `examples/runCfhtTest.sh`  : CFHT Run initialization, ingest, measurement, and astrometry validation.
 * `examples/runDecamTest.sh` : DECam Run initialization, ingest, measurement, and astrometry validation.
-* `examples/runCfht.list`    : CRHT list of vistits / ccd to be processed by processCcd
-* `examples/runDecam.list`   : DECam list of vistits / ccd to be processed by processCcd
-* `examples/runCfht.yaml`   : CFHT YAML file with visits, ccd, paramaters for validateDrp.
-* `examples/runDecam.yaml`   : DECam YAML file with visits, ccd, paramaters for validateDrp.
-* `examples/runDecamCosmos.yaml`   : DECam COSMOS YAML file with visits, ccd, paramaters for validateDrp.
-* `config/newAstrometryConfig.py`  : configuration for running processCcd with the new AstrometryTask
-* `config/anetAstrometryConfig.py` : configuration for running processCcd ANetAstrometryTask
-* `bin.src/validateDrp.py`   : Analyze output data produced by processCcd.py
-* `python/lsst/validate/drp/srdSpec.py` : class to contain the SRD specifications
-* `python/lsst/validate/drp/calcSrd.py` : calculate metrics defined by the LSST SRC.
-* `python/lsst/validate/drp/plot.py` : plotting routines
-* `python/lsst/validate/drp/check.py` : coordination and calculation routines.
-* `python/lsst/validate/drp/print.py` : printing routines
+* `examples/runExample.sh`  : General example runner.
+* `examples/Cfht.yaml`   : CFHT YAML file with visits, ccd, paramaters for validateDrp.
+* `examples/Decam.yaml`   : DECam YAML file with visits, ccd, paramaters for validateDrp.
+* `examples/DecamCosmos.yaml`   : DECam COSMOS YAML file with visits, ccd, paramaters for validateDrp.
 * `python/lsst/validate/drp/base.py` : base routines for the module
+* `python/lsst/validate/drp/calcSrd.py` : calculate metrics defined by the LSST SRC.
+* `python/lsst/validate/drp/check.py` : coordination and calculation routines.
+* `python/lsst/validate/drp/io.py` : JSON input and output routines.
+* `python/lsst/validate/drp/plot.py` : plotting routines
+* `python/lsst/validate/drp/print.py` : printing routines
+* `python/lsst/validate/drp/srdSpec.py` : pipeBase Struct with SRD specifications.  Access routine helper.
 * `python/lsst/validate/drp/util.py` : utility routines
 * `README.md` : THIS FILE.  Guide and examples.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ The last line of the output will give the median astrometric scatter (in milliar
 ------
 There are also "Quick" versions to run one CCD for quick debugging and verification that things are running properly: `examples/runCfhtQuickTest.sh` and `examples/runDecamQuickTest.sh`.
 
+------
+Multiple filters can be processed by specifying a filter name for each visit.  See `examples/DecamCosmos.yaml` for an example.  In brief:
+```
+# Visit - filter are matched pairs.
+visits: [176837, 176839, 176840, 176841, 176842, 176843, 176844, 176845, 176846,
+         177341, 177342, 177343, 177344, 177345, 177346,]
+filter: ['z', 'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z',
+         'r', 'r', 'r', 'r', 'r', 'r', ]
+# ccd list is iterated through for each visit-filter pair
+ccdnum: [10, 11, 12, 13, 14, 15, 16, 17, 18]
+```
 
 ------
 While `examples/runCfhtTest.sh` and `examples/runDecamTest.sh` respectively do all of the processing and validation analysis, below are some examples of running the processing/measurement steps individually.  While these examples are from  the CFHT validation example, analogous commands would work for DECam.

--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -62,5 +62,10 @@ if __name__ == "__main__":
 
     configFile = sys.argv[2]
 
-    args = util.loadDataIdsAndParameters(configFile)
-    validate.run(repo, *args)
+    visitDataIds, good_mag_limit, medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
+        util.loadDataIdsAndParameters(configFile)
+    validate.run(repo, visitDataIds,
+                 good_mag_limit=good_mag_limit, 
+                 medianAstromscatterRef=medianAstromscatterRef, 
+                 medianPhotoscatterRef=medianPhotoscatterRef, 
+                 matchRef=matchRef)

--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -44,12 +44,6 @@ if __name__ == "__main__":
         Summary of key metrics
     *.png
         Plots of key metrics.  Generated in current working directory.
-
-    Notes
-    -----
-    Currently can only work on one filter at a time.
-      -- There is no logic to organize things by filter in the analysis,
-      -- There is no syntax for matching visits with filters in the YAML file.
     """
     if len(sys.argv) < 2:
         print(helpMessage)

--- a/examples/DecamCosmos.yaml
+++ b/examples/DecamCosmos.yaml
@@ -5,6 +5,10 @@ good_mag_limit: 21.0  # Only consider stars bright than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 10000  # Number of stars expected to match.  Update if you change the ccd list below
-visits: [176837, 176839, 176840, 176841, 176842, 176843, 176844, 176845, 176846]
-filter: 'z'
-ccd: [10, 11, 12, 13, 14, 15, 16, 17, 18]
+# Visit - filter are matched pairs.
+visits: [176837, 176839, 176840, 176841, 176842, 176843, 176844, 176845, 176846,
+         177341, 177342, 177343, 177344, 177345, 177346,]
+filter: ['z', 'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z',
+         'r', 'r', 'r', 'r', 'r', 'r', ]
+# ccd list is iterated through for each visit-filter pair
+ccdnum: [10, 11, 12, 13, 14, 15, 16, 17, 18]

--- a/tests/testJson.py
+++ b/tests/testJson.py
@@ -24,6 +24,7 @@
 
 from __future__ import print_function
 
+import json
 import os
 import sys
 import tempfile
@@ -44,6 +45,11 @@ class JsonTestCase(unittest.TestCase):
         ps = pipeBase.Struct(foo=2, bar=[10, 20], hard=np.array([5,10]))
         _, tmpFilepath = tempfile.mkstemp(suffix='.json')
         saveKpmToJson(ps, tmpFilepath)
+        self.assertTrue(os.path.exists(tmpFilepath))
+    
+        readBackData = json.load(open(tmpFilepath))
+        self.assertEqual(readBackData['foo'], 2)
+
         os.unlink(tmpFilepath)
 
 
@@ -61,7 +67,6 @@ def run(shouldExit=False):
     """Run the tests"""
     utilsTests.run(suite(), shouldExit)
 
+
 if __name__ == "__main__":
-    if "--display" in sys.argv:
-        display = True
     run(True)

--- a/tests/testLoading.py
+++ b/tests/testLoading.py
@@ -46,7 +46,7 @@ class LoadDataTestCase(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def testLoadingOfConfigFile(self):
+    def testLoadingOfConfigFileParameters(self):
         dataIds, good_mag_limit, \
             medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
                 util.loadDataIdsAndParameters(self.configFile)
@@ -54,6 +54,11 @@ class LoadDataTestCase(unittest.TestCase):
         self.assertAlmostEqual(medianAstromscatterRef, 25)
         self.assertAlmostEqual(medianPhotoscatterRef, 25)
         self.assertAlmostEqual(matchRef, 5000)
+
+    def testLoadingOfConfigFileDataIds(self):
+        dataIds, good_mag_limit, \
+            medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
+                util.loadDataIdsAndParameters(self.configFile)
         # Tests of the dict entries require constructing and comparing sets
         self.assertEqual(set(['r']), set([d['filter'] for d in dataIds]))
         self.assertEqual(set([849375, 850587]),


### PR DESCRIPTION
Straightfoward.  Minor syntax change in building of dataIds from YAML config file.

validate.py now has an overall parsing for all filters, then hands off to do a oneFilter version of the analysis for each filter.  There is no cross-filter matching done.

Improve JSON test (yes, technically out of scope, but indulge me to include it here).
