### PR TITLE
DM-5120: Add intelligence to `validate_drp` so it does "A Reasonable Thing" on an unknown output repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 Validate an LSST DM processCcd.py output repository
 against a set of LSST Science Requirements Document Key Performance Metrics.
 
+```
+setup validate_drp
+validateDrp.py CFHT/output
+```
+
+will produces output, plots, JSON files analyzing the processed data in `CFHT/output`.  Metrics will be separately calculated for each filter represented in the repository.  Replace `CFHT/output` with your favorite processed data repository and you will get reasonable output.
+
+One can run `validateDrp.py` in any of the following modes:
+1. use no configuration file (as above)
+2. pass a configuration file with just validation parameters (good_mag_limit, number of expected matches, ...) but no dataId specifications
+3. pass a configuration file that specifies validation parameters and the dataIds to process.  See examples below for use with a `--configFile`
+
+Caveat:  Will likely not successfully run on more than 500 catalogs per band due to memory limits and inefficiencies in the current matching approach.
+
+------
 This package also includes examples that run processCcd task on some 
 CFHT data and DECam data
 and validate the astrometric and photometric repeatability of the results.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Once these basic steps are completed, then you can run any of the following:
 * To process all CCDs with the old ANetAstrometryTask and 6 threads:
     ```
     processCcd.py CFHT/input @examples/runCfht.list --configfile config/anetAstrometryConfig.py --clobber-config -j 6 --output CFHT/output
-    validateDrp.py CFHT/output examples/runCfht.yaml
+    validateDrp.py CFHT/output --configFile examples/runCfht.yaml
     ```
 
 * To process one CCD with the new AstrometryTask:
@@ -122,7 +122,7 @@ Once these basic steps are completed, then you can run any of the following:
 
 * Run the validation test
     ```
-    validateDrp.py CFHT/output examples/runCfht.yaml
+    validateDrp.py CFHT/output --configFile examples/runCfht.yaml
     ```
 
 Note that the example validation test selects several of the CCDs and will fail if you just pass it a repository with 1 visit or just 1 CCD.

--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -36,10 +36,13 @@ if __name__ == "__main__":
     Produces results to:
     STDOUT
         Summary of key metrics
-    *.png
+    REPONAME*.png
         Plots of key metrics.  Generated in current working directory.
-    *.json
+    REPONAME*.json
         JSON serialization of each KPM.
+
+    where REPONAME is based on the repository name but with path separators 
+    replaced with underscores.  E.g., "Cfht/output" -> "Cfht_output_"
     """
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('repo', type=str, 

--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
                         help='path to a repository containing the output of processCcd')
     parser.add_argument('--configFile', '-c', type=str, default=None,
                         help='YAML configuration file validation parameters and dataIds.')
+    parser.add_argument('--verbose', '-v', default=False, action='store_true',
+                        help='Display additional information about the analysis.')
     
     args = parser.parse_args()
 
@@ -53,8 +55,9 @@ if __name__ == "__main__":
         print("Could not find repo %r" % (args.repo,))
         sys.exit(1)
 
+    kwargs = {}
     if args.configFile:
-        visitDataIds, good_mag_limit, medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
+        dataIds, good_mag_limit, medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
             util.loadDataIdsAndParameters(args.configFile)
         kwargs = {
             'good_mag_limit': good_mag_limit, 
@@ -62,9 +65,11 @@ if __name__ == "__main__":
             'medianPhotoscatterRef': medianPhotoscatterRef, 
             'matchRef': matchRef,
             }
-    else:
-        visitDataIds = util.discoverDataIds(args.repo)
-        print("VISITDATAIDS: ", visitDataIds)
-        kwargs = {}
 
-    validate.run(args.repo, visitDataIds, **kwargs)
+    if not args.configFile or not dataIds:
+        dataIds = util.discoverDataIds(args.repo)
+        if args.verbose:
+            print("VISITDATAIDS: ", dataIds)
+
+    kwargs['verbose'] = args.verbose
+    validate.run(args.repo, dataIds, **kwargs)

--- a/examples/runExample.sh
+++ b/examples/runExample.sh
@@ -69,7 +69,7 @@ ${PROCESSCCD} "${INPUT}" --output "${OUTPUT}" \
 
 # Run astrometry check on src
 echo "validating"
-validateDrp.py "${OUTPUT}" "${YAMLCONFIG}"
+validateDrp.py "${OUTPUT}" --configFile "${YAMLCONFIG}"
 
 if [ $? != 0 ]; then
    print_error "Validation failed"

--- a/python/lsst/validate/drp/calcSrd.py
+++ b/python/lsst/validate/drp/calcSrd.py
@@ -32,7 +32,7 @@ from .util import averageRaFromCat, averageDecFromCat
 from .srdSpec import srdSpec, getAstrometricSpec
 
 
-def calcPA1(matches, magKey, numRandomShuffles=50):
+def calcPA1(matches, magKey, numRandomShuffles=50, verbose=False):
     """Calculate the photometric repeatability of measurements across a set of observations.
 
     Parameters
@@ -45,6 +45,8 @@ def calcPA1(matches, magKey, numRandomShuffles=50):
          where `allMatches` is the result of lsst.afw.table.MultiMatch.finish()
     numRandomShuffles : int
         Number of times to draw random pairs from the different observations.
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     Returns
     -------
@@ -158,7 +160,7 @@ def doCalcPA1(groupView, magKey):
                            magDiffsUnits='mmag', magMeanUnits='mag')
 
 
-def calcPA2(groupView, magKey):
+def calcPA2(groupView, magKey, verbose=False):
     """Calculate the fraction of outliers from PA1.
 
     Calculate the fraction of outliers from the median RMS characterizaing
@@ -172,6 +174,8 @@ def calcPA2(groupView, magKey):
          The lookup key of the field storing the magnitude of interest.
          E.g., `magKey = allMatches.schema.find("base_PsfFlux_mag").key`
          where `allMatches` is a the result of lsst.afw.table.MultiMatch.finish()
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     Returns
     -------
@@ -427,7 +431,9 @@ def calcAM3(*args, **kwargs):
     return calcAMx(*args, x=3, D=srdSpec.D3, width=2, **kwargs)
 
 def calcAMx(groupView, D=5, width=2, magRange=None,
-            x=None, level="design"):
+            x=None, level="design", 
+            verbose=False,
+           ):
     """Calculate the SRD definition of astrometric performance
 
     Parameters
@@ -501,7 +507,7 @@ def calcAMx(groupView, D=5, width=2, magRange=None,
     annulus = D + (width/2)*np.array([-1, +1])
 
     rmsDistances, annulus, magRange = \
-        calcRmsDistances(groupView, annulus, magRange=magRange)
+        calcRmsDistances(groupView, annulus, magRange=magRange, verbose=verbose)
 
     if not list(rmsDistances):
         raise ValidateErrorNoStars('No stars found that are %.1f--%.1f arcmin apart.' %
@@ -534,7 +540,7 @@ def calcAMx(groupView, D=5, width=2, magRange=None,
         )
 
 
-def calcRmsDistances(groupView, annulus, magRange=None):
+def calcRmsDistances(groupView, annulus, magRange=None, verbose=False):
     """Calculate the RMS distance of a set of matched objects over visits.
 
     Parameters
@@ -548,6 +554,8 @@ def calcRmsDistances(groupView, annulus, magRange=None):
     magRange : 2-element list or tuple of float, optional
         Magnitude range from which to select objects.
         Default of `None` will result in all objects being considered.
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     Returns
     -------
@@ -599,7 +607,8 @@ def calcRmsDistances(groupView, annulus, magRange=None):
             distances = matchVisitComputeDistance(visit[obj1], ra[obj1], dec[obj1],
                                                   visit[obj2], ra[obj2], dec[obj2])
             if not distances:
-                print("No matching visits found for objs: %d and %d" % (obj1, obj2))
+                if verbose:
+                    print("No matching visits found for objs: %d and %d" % (obj1, obj2))
                 continue
 
             finiteEntries, = np.where(np.isfinite(distances))

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -109,6 +109,7 @@ def plotAstrometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
     plt.suptitle("Astrometry Check : %s" % outputPrefix.rstrip('_'), fontsize=30)
     plotPath = outputPrefix+"check_astrometry.png"
     plt.savefig(plotPath, format="png")
+    plt.close(fig)
 
 
 def expModel(x, a, b, norm):
@@ -233,6 +234,7 @@ def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
     plt.suptitle("Photometry Check : %s" % outputPrefix.rstrip('_'), fontsize=30)
     plotPath = outputPrefix+"check_photometry.png"
     plt.savefig(plotPath, format="png")
+    plt.close(fig)
 
 
 def plotPA1(pa1, outputPrefix=""):
@@ -287,6 +289,7 @@ def plotPA1(pa1, outputPrefix=""):
     plt.suptitle("PA1: %s" % outputPrefix.rstrip('_'))
     plotPath = "%s%s" % (outputPrefix, "PA1.png")
     plt.savefig(plotPath, format="png")
+    plt.close(fig)
 
 
 def plotAM1(*args, **kwargs):
@@ -347,3 +350,4 @@ def plotAMx(AMx, outputPrefix=""):
               (AMx.name, int(sum(AMx.annulus)/2), AMx.DUnits.upper(), AMx.magRange[0], AMx.magRange[1])
 
     plt.savefig(figName, dpi=300)
+    plt.close(fig)

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -160,8 +160,11 @@ def loadDataIdsAndParameters(configFile):
     data = yaml.load(stream)
 
     ccdKeyName = getCcdKeyName(data)
-    visitDataIds = constructDataIds(data['filter'], data['visits'],
-                                    data[ccdKeyName], ccdKeyName)
+    try:
+        visitDataIds = constructDataIds(data['filter'], data['visits'],
+                                        data[ccdKeyName], ccdKeyName)
+    except KeyError as ke:
+        visitDataIds = []
 
     return (visitDataIds,
             data['good_mag_limit'],
@@ -282,10 +285,10 @@ def constructRunList(filter, visits, ccds, ccdKeyName='ccd'):
     return runList
 
 
-def calcOrNone(func, x, ErrorClass):
+def calcOrNone(func, x, ErrorClass, **kwargs):
     """Calculate the `func` and return result.  If it raises ErrorClass, return None."""
     try:
-        out = func(x)
+        out = func(x, **kwargs)
     except ErrorClass as e:
         print(e)
         out = None

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -25,6 +25,7 @@ import yaml
 
 import lsst.afw.geom as afwGeom
 import lsst.afw.coord as afwCoord
+import lsst.daf.persistence as dafPersist
 
 
 def averageRaDec(ra, dec):
@@ -107,6 +108,38 @@ def repoNameToPrefix(repo):
     """
 
     return repo.lstrip('\.').strip(os.sep).replace(os.sep, "_") + "_"
+
+
+def discoverDataIds(repo, **kwargs):
+    """Retrieve a list of all dataIds in a repo.
+
+    Parameters
+    ----------
+    repo : str
+        Path of a repository with 'src' entries.
+
+    Returns
+    -------
+    list
+        dataIds in the butler that exist.
+
+    Notes
+    -----
+    May consider making this an iterator if large N becomes important.
+    However, will likely need to know things like, "all unique filters"
+    of a data set anyway, so would need to go through chain at least once.
+    """
+    butler = dafPersist.Butler(repo)
+    thisSubset = butler.subset(datasetType='src', **kwargs)
+    # This totally works, but would be better to do this as a TaskRunner?
+    dataIds = [dr.dataId for dr in thisSubset 
+               if dr.datasetExists(datasetType='src') and dr.datasetExists(datasetType='calexp')]
+    # Make sure we have the filter information
+    for dId in dataIds:
+        filterForThisDataId = butler.queryMetadata(datasetType='src', key=None, format=['filter'], dataId=dId)[0]
+        dId['filter'] = filterForThisDataId
+
+    return dataIds
 
 
 def loadDataIdsAndParameters(configFile):

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -132,11 +132,12 @@ def discoverDataIds(repo, **kwargs):
     butler = dafPersist.Butler(repo)
     thisSubset = butler.subset(datasetType='src', **kwargs)
     # This totally works, but would be better to do this as a TaskRunner?
-    dataIds = [dr.dataId for dr in thisSubset 
+    dataIds = [dr.dataId for dr in thisSubset
                if dr.datasetExists(datasetType='src') and dr.datasetExists(datasetType='calexp')]
     # Make sure we have the filter information
     for dId in dataIds:
-        filterForThisDataId = butler.queryMetadata(datasetType='src', key=None, format=['filter'], dataId=dId)[0]
+        response = butler.queryMetadata(datasetType='src', key=None, format=['filter'], dataId=dId)
+        filterForThisDataId = response[0]
         dId['filter'] = filterForThisDataId
 
     return dataIds

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -102,11 +102,11 @@ def loadAndMatchData(repo, visitDataIds,
             continue
         except TypeError as te:
             # DECam images that haven't been properly reformatted
-            # can trigger a TypeError because of a residual FITS header 
-            # LTV2 which is a float instead of the expected integer. 
+            # can trigger a TypeError because of a residual FITS header
+            # LTV2 which is a float instead of the expected integer.
             # This generates an error of the form:
             #
-            # lsst::pex::exceptions::TypeError: 'LTV2 has mismatched type'  
+            # lsst::pex::exceptions::TypeError: 'LTV2 has mismatched type'
             #
             # See, e.g., DM-2957 for details.
             print(te)

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -39,7 +39,8 @@ from .io import saveKpmToJson
 
 
 def loadAndMatchData(repo, visitDataIds,
-                     matchRadius=afwGeom.Angle(1, afwGeom.arcseconds)):
+                     matchRadius=afwGeom.Angle(1, afwGeom.arcseconds),
+                     verbose=False):
     """Load data from specific visit.  Match with reference.
 
     Parameters
@@ -52,6 +53,8 @@ def loadAndMatchData(repo, visitDataIds,
         The `calexp` cpixel image is needed for the photometric calibration.
     matchRadius :  afwGeom.Angle().
         Radius for matching.
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     Returns
     -------
@@ -113,7 +116,7 @@ def loadAndMatchData(repo, visitDataIds,
     return allMatches
 
 
-def analyzeData(allMatches, good_mag_limit=19.5):
+def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
     """Calculate summary statistics for each star.
 
     Parameters
@@ -122,6 +125,8 @@ def analyzeData(allMatches, good_mag_limit=19.5):
         GroupView object with matches.
     good_mag_limit : float, optional
         Minimum average brightness (in magnitudes) for a star to be considered.
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     Returns
     -------
@@ -230,7 +235,9 @@ def run(repo, visitDataIds, outputPrefix=None, **kwargs):
 def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
         medianAstromscatterRef=25, medianPhotoscatterRef=25, matchRef=500,
         makePrint=True, makePlot=True, makeJson=True,
-        outputPrefix=None):
+        outputPrefix=None,
+        verbose=False,
+        ):
     """Main executable for the case where there is just one filter.
 
     Plot files and JSON files are generated in the local directory
@@ -263,14 +270,16 @@ def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
         Create JSON output file for metrics.  Saved to current working directory.
     outputPrefix : str, optional
         Specify the beginning filename for output files.
+    verbose : bool, optional
+        Output additional information on the analysis steps.
 
     """
 
     if outputPrefix is None:
         outputPrefix = repoNameToPrefix(repo)
 
-    allMatches = loadAndMatchData(repo, visitDataIds)
-    struct = analyzeData(allMatches, good_mag_limit)
+    allMatches = loadAndMatchData(repo, visitDataIds, verbose=verbose)
+    struct = analyzeData(allMatches, good_mag_limit, verbose=verbose)
     magavg = struct.mag
     magerr = struct.magerr
     magrms = struct.magrms
@@ -295,9 +304,9 @@ def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key
 
-    AM1, AM2, AM3 = [calcOrNone(func, safeMatches, ValidateErrorNoStars)
+    AM1, AM2, AM3 = [calcOrNone(func, safeMatches, ValidateErrorNoStars, verbose=verbose)
                      for func in (calcAM1, calcAM2, calcAM3)]
-    PA1, PA2 = [func(safeMatches, magKey) for func in (calcPA1, calcPA2)]
+    PA1, PA2 = [func(safeMatches, magKey, verbose=verbose) for func in (calcPA1, calcPA2)]
 
     if makePrint:
         printPA1(PA1)

--- a/tests/runCfhtParametersOnly.yaml
+++ b/tests/runCfhtParametersOnly.yaml
@@ -1,0 +1,7 @@
+# Configuration information for validate_drp to 
+#   1. build the list of data IDs to analyze
+#   2. load the default magnitude ranges, expected peformance, and num matches
+good_mag_limit: 21.0  # Only consider stars bright than this limit
+medianAstromscatterRef: 25  # expected astrometric variability [mas]
+medianPhotoscatterRef: 25  # expected photometric variability [mmag]
+matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/tests/testLoading.py
+++ b/tests/testLoading.py
@@ -42,6 +42,7 @@ class LoadDataTestCase(unittest.TestCase):
         validateDrpDir = lsst.utils.getPackageDir('validate_drp')
         testDataDir = os.path.join(validateDrpDir, 'tests')
         self.configFile = os.path.join(testDataDir, 'runCfht.yaml')
+        self.configFileNoDataIds = os.path.join(testDataDir, 'runCfhtParametersOnly.yaml')
 
     def tearDown(self):
         pass
@@ -64,6 +65,12 @@ class LoadDataTestCase(unittest.TestCase):
         self.assertEqual(set([849375, 850587]),
                          set([d['visit'] for d in dataIds]))
 
+    def testLoadingEmptyDataIds(self):
+        dataIds, good_mag_limit, \
+            medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
+                util.loadDataIdsAndParameters(self.configFileNoDataIds)
+        # Tests of the dict entries require constructing and comparing sets
+        self.assertFalse(dataIds)
 
 def suite():
     """Returns a suite containing all the test cases in this module."""


### PR DESCRIPTION
validateDrp.py Cfht/output

will now do "something reasonable" with no further configuration information needed.
