### PR TITLE
DM-5252: Base "bright star" cut on S/N instead of magnitudes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ will produces output, plots, JSON files analyzing the processed data in `CFHT/ou
 
 One can run `validateDrp.py` in any of the following modes:
 1. use no configuration file (as above)
-2. pass a configuration file with just validation parameters (good_mag_limit, number of expected matches, ...) but no dataId specifications
+2. pass a configuration file with just validation parameters (brightSnr, number of expected matches, ...) but no dataId specifications
 3. pass a configuration file that specifies validation parameters and the dataIds to process.  See examples below for use with a `--configFile`
 
 Caveat:  Will likely not successfully run on more than 500 catalogs per band due to memory limits and inefficiencies in the current matching approach.

--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -60,10 +60,10 @@ if __name__ == "__main__":
 
     kwargs = {}
     if args.configFile:
-        dataIds, good_mag_limit, medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
+        dataIds, brightSnr, medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
             util.loadDataIdsAndParameters(args.configFile)
         kwargs = {
-            'good_mag_limit': good_mag_limit, 
+            'brightSnr': brightSnr, 
             'medianAstromscatterRef': medianAstromscatterRef, 
             'medianPhotoscatterRef': medianPhotoscatterRef, 
             'matchRef': matchRef,

--- a/examples/Cfht.yaml
+++ b/examples/Cfht.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars with higher S/N than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/examples/CfhtQuick.yaml
+++ b/examples/CfhtQuick.yaml
@@ -4,7 +4,7 @@
 brightSnr: 100  # Only consider stars with higher S/N than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
-matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below
+matchRef: 700  # Number of stars expected to match.  Update if you change the ccd list below
 visits: [849375, 850587]
 filter: 'r'
 ccd: [12]

--- a/examples/CfhtQuick.yaml
+++ b/examples/CfhtQuick.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars with higher S/N than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/examples/Decam.yaml
+++ b/examples/Decam.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars with higher S/N than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 10000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/examples/DecamCosmos.yaml
+++ b/examples/DecamCosmos.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars bright than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 10000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/examples/DecamQuick.yaml
+++ b/examples/DecamQuick.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars bright than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 10000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -91,23 +91,21 @@ def positionRms(cat):
     return pos_rms
 
 
-def checkAstrometry(mag, mmagrms, dist, match,
-                    good_mag_limit=19.5,
+def checkAstrometry(snr, dist, match,
+                    brightSnr=100,
                     medianRef=100, matchRef=500):
     """Print out the astrometric scatter for all stars, and for good stars.
 
     Parameters
     ----------
-    mag : list or numpy.array
-        Average magnitudes of each star
-    mmagrms ; list or numpy.array
-        Magnitude RMS of the multiple observation of each star.
+    snr : list or numpy.array
+        Average PSF flux SNR of each star
     dist : list or numpy.array
         Distances between successive measurements of one star
     match : int
         Number of stars matched.
 
-    good_mag_limit : float, optional
+    brightSnr : float, optional
         Minimum average brightness (in magnitudes) for a star to be considered.
     medianRef : float, optional
         Median reference astrometric scatter in milliarcseconds.
@@ -129,10 +127,10 @@ def checkAstrometry(mag, mmagrms, dist, match,
     print("Median value of the astrometric scatter - all magnitudes: %.3f %s" %
           (np.median(dist), "mas"))
 
-    bright = np.where(np.asarray(mag) < good_mag_limit)
+    bright = np.where(np.asarray(snr) > brightSnr)
     astromScatter = np.median(np.asarray(dist)[bright])
-    print("Astrometric scatter (median) - mag < %.1f : %.1f %s" %
-          (good_mag_limit, astromScatter, "mas"))
+    print("Astrometric scatter (median) - snr > %.1f : %.1f %s" %
+          (brightSnr, astromScatter, "mas"))
 
     if astromScatter > medianRef:
         print("Median astrometric scatter %.1f %s is larger than reference : %.1f %s " %
@@ -143,13 +141,15 @@ def checkAstrometry(mag, mmagrms, dist, match,
     return astromScatter
 
 
-def checkPhotometry(mag, mmagrms, dist, match,
-                    good_mag_limit=19.5,
+def checkPhotometry(snr, mag, mmagrms, dist, match,
+                    brightSnr=100,
                     medianRef=100, matchRef=500):
     """Print out the astrometric scatter for all stars, and for good stars.
 
     Parameters
     ----------
+    snr : list or numpy.array
+        Median SNR of PSF flux
     mag : list or numpy.array
         Average magnitudes of each star
     mmagrms ; list or numpy.array
@@ -158,9 +158,8 @@ def checkPhotometry(mag, mmagrms, dist, match,
         Distances between successive measurements of one star
     match : int
         Number of stars matched.
-
-    good_mag_limit : float, optional
-        Minimum average brightness (in magnitudes) for a star to be considered.
+    brightSnr : float, optional
+        Minimum SNR for a star to be considered "bright".
     medianRef : float, optional
         Median reference astrometric scatter in millimagnitudes
     matchRef : int, optional
@@ -181,10 +180,10 @@ def checkPhotometry(mag, mmagrms, dist, match,
     print("Median value of the photometric scatter - all magnitudes: %.3f %s" %
           (np.median(mmagrms), "mmag"))
 
-    bright = np.where(np.asarray(mag) < good_mag_limit)
+    bright = np.where(np.asarray(snr) > brightSnr)
     photoScatter = np.median(np.asarray(mmagrms)[bright])
-    print("Photometric scatter (median) - mag < %.1f : %.1f %s" %
-          (good_mag_limit, photoScatter, "mmag"))
+    print("Photometric scatter (median) - SNR > %.1f : %.1f %s" %
+          (brightSnr, photoScatter, "mmag"))
 
     if photoScatter > medianRef:
         print("Median photometric scatter %.3f %s is larger than reference : %.3f %s "

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -48,7 +48,7 @@ def plotOutlinedLines(ax, x1, x2, x1_color=color['all'], x2_color=color['bright'
     ax.axhline(x2, color=x2_color, linewidth=3)
 
 
-def plotAstrometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
+def plotAstrometry(snr, mmagrms, dist, match, brightSnr=100,
                    outputPrefix=""):
     """Plot angular distance between matched sources from different exposures.
 
@@ -56,25 +56,22 @@ def plotAstrometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
 
     Parameters
     ----------
-    mag : list or numpy.array
-        Average Magnitude
-    mmagerr : list or numpy.array
-        Average Magnitude uncertainty [millimag]
+    snr : list or numpy.array
+        Median SNR of PSF flux
     mmagrms ; list or numpy.array
         Magnitude RMS across visits [millimag]
     dist : list or numpy.array
         Separation from reference [mas]
     match : int
         Number of stars matched.
-    good_mag_limit : float, optional
-        Minimum average brightness (in magnitudes) for a star to be considered.
+    brightSnr : float, optional
+        Minimum SNR for a star to be considered "bright".
     outputPrefix : str, optional
         Prefix to use for filename of plot file.  Will also be used in plot titles.
         E.g., outputPrefix='Cfht_output_r_' will result in a file named
            'Cfht_output_r_check_astrometry.png'
     """
-
-    bright, = np.where(np.asarray(mag) < good_mag_limit)
+    bright, = np.where(np.asarray(snr) > brightSnr)
 
     dist_median = np.median(dist)
     bright_dist_median = np.median(np.asarray(dist)[bright])
@@ -85,7 +82,7 @@ def plotAstrometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
                histtype='stepfilled', orientation='horizontal')
     ax[0].hist(np.asarray(dist)[bright], bins=100, color=color['bright'],
                histtype='stepfilled', orientation='horizontal',
-               label='mag < %.1f' % good_mag_limit)
+               label='SNR > %.1f' % brightSnr)
 
     ax[0].set_ylim([0., 500.])
     ax[0].set_ylabel("Distance [mas]")
@@ -94,13 +91,13 @@ def plotAstrometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
                     x=0.55, y=0.88)
     plotOutlinedLines(ax[0], dist_median, bright_dist_median)
 
-    ax[1].scatter(mag, dist, s=10, color=color['all'], label='All')
-    ax[1].scatter(np.asarray(mag)[bright], np.asarray(dist)[bright], s=10,
+    ax[1].scatter(snr, dist, s=10, color=color['all'], label='All')
+    ax[1].scatter(np.asarray(snr)[bright], np.asarray(dist)[bright], s=10,
                   color=color['bright'],
-                  label='mag < %.1f' % good_mag_limit)
-    ax[1].set_xlabel("Magnitude")
+                  label='SNR > %.1f' % brightSnr)
+    ax[1].set_xlabel("SNR")
+    ax[1].set_xscale("log")
     ax[1].set_ylabel("Distance [mas]")
-    ax[1].set_xlim([17, 24])
     ax[1].set_ylim([0., 500.])
     ax[1].set_title("# of matches : %d, %d" % (len(bright), match))
     ax[1].legend(loc='upper left')
@@ -150,12 +147,14 @@ def plotMagerrFit(*args, **kwargs):
     plotExpFit(*args, **kwargs)
 
 
-def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
+def plotPhotometry(snr, mag, mmagerr, mmagrms, dist, match, brightSnr=100,
                    outputPrefix=""):
     """Plot photometric RMS for matched sources.
 
     Parameters
     ----------
+    snr : list or numpy.array
+        Median SNR of PSF flux
     mag : list or numpy.array
         Average Magnitude
     mmagerr : list or numpy.array
@@ -166,13 +165,15 @@ def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
         Separation from reference [mas]
     match : int
         Number of stars matched.
+    brightSnr : float, optional
+        Minimum SNR for a star to be considered "bright".
     outputPrefix : str, optional
         Prefix to use for filename of plot file.  Will also be used in plot titles.
         E.g., outputPrefix='Cfht_output_r_' will result in a file named
            'Cfht_output_r_check_photometry.png'
     """
 
-    bright, = np.where(np.asarray(mag) < good_mag_limit)
+    bright, = np.where(np.asarray(snr) > brightSnr)
 
     mmagrms_median = np.median(mmagrms)
     bright_mmagrms_median = np.median(np.asarray(mmagrms)[bright])
@@ -181,7 +182,7 @@ def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
     ax[0][0].hist(mmagrms, bins=100, range=(0, 500), color=color['all'], label='All',
                   histtype='stepfilled', orientation='horizontal')
     ax[0][0].hist(np.asarray(mmagrms)[bright], bins=100, range=(0, 500), color=color['bright'],
-                  label='mag < %.1f' % good_mag_limit,
+                  label='SNR > %.1f' % brightSnr,
                   histtype='stepfilled', orientation='horizontal')
     ax[0][0].set_ylim([0, 500])
     ax[0][0].set_ylabel("RMS [mmag]")
@@ -193,7 +194,7 @@ def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
     ax[0][1].scatter(mag, mmagrms, s=10, color=color['all'], label='All')
     ax[0][1].scatter(np.asarray(mag)[bright], np.asarray(mmagrms)[bright],
                      s=10, color=color['bright'],
-                     label='mag < %.1f' % good_mag_limit)
+                     label='SNR > %.1f' % brightSnr)
 
     ax[0][1].set_xlabel("Magnitude")
     ax[0][1].set_ylabel("RMS [mmag]")
@@ -206,7 +207,7 @@ def plotPhotometry(mag, mmagerr, mmagrms, dist, match, good_mag_limit=19.5,
     ax[1][0].scatter(mmagrms, mmagerr, s=10, color=color['all'], label='All')
     ax[1][0].scatter(np.asarray(mmagrms)[bright], np.asarray(mmagerr)[bright],
                      s=10, color=color['bright'],
-                     label='mag < %.1f' % good_mag_limit)
+                     label='SNR > %.1f' % brightSnr)
     ax[1][0].set_xscale('log')
     ax[1][0].set_yscale('log')
     ax[1][0].plot([0, 1000], [0, 1000],

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -150,12 +150,12 @@ def loadDataIdsAndParameters(configFile):
     ----------
     configFile : str
         YAML file that stores visit, filter, ccd,
-        good_mag_limit, medianAstromscatterRef, medianPhotoscatterRef, matchRef
+        brightSnr, medianAstromscatterRef, medianPhotoscatterRef, matchRef
 
     Returns
     -------
     dict, float, float, float
-        dataIds, good_mag_limit, medianRef, matchRef
+        dataIds, brightSnr, medianRef, matchRef
     """
     stream = open(configFile, mode='r')
     data = yaml.load(stream)
@@ -168,7 +168,7 @@ def loadDataIdsAndParameters(configFile):
         visitDataIds = []
 
     return (visitDataIds,
-            data['good_mag_limit'],
+            data['brightSnr'],
             data['medianAstromscatterRef'],
             data['medianPhotoscatterRef'],
             data['matchRef'],

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -262,7 +262,7 @@ def run(repo, visitDataIds, outputPrefix=None, **kwargs):
         runOneFilter(repo, theseVisitDataIds, outputPrefix=thisOutputPrefix, **kwargs)
 
 
-def runOneFilter(repo, visitDataIds, brightSnr=100, good_mag_limit=19.5,
+def runOneFilter(repo, visitDataIds, brightSnr=100,
         medianAstromscatterRef=25, medianPhotoscatterRef=25, matchRef=500,
         makePrint=True, makePlot=True, makeJson=True,
         outputPrefix=None,

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -79,6 +79,7 @@ def loadAndMatchData(repo, visitDataIds,
     schema = butler.get(dataset + "_schema", immediate=True).schema
     mapper = SchemaMapper(schema)
     mapper.addMinimalSchema(schema)
+    mapper.addOutputField(Field[float]('base_PsfFlux_snr', "PSF flux SNR"))
     mapper.addOutputField(Field[float]('base_PsfFlux_mag', "PSF magnitude"))
     mapper.addOutputField(Field[float]('base_PsfFlux_magerr', "PSF magnitude uncertainty"))
     newSchema = mapper.getOutputSchema()
@@ -122,6 +123,7 @@ def loadAndMatchData(repo, visitDataIds,
         # create temporary catalog
         tmpCat = SourceCatalog(SourceCatalog(newSchema).table)
         tmpCat.extend(oldSrc, mapper=mapper)
+        tmpCat['base_PsfFlux_snr'][:] = tmpCat['base_PsfFlux_flux'] / tmpCat['base_PsfFlux_fluxSigma']
         with afwImageUtils.CalibNoThrow():
             (tmpCat['base_PsfFlux_mag'][:], tmpCat['base_PsfFlux_magerr'][:]) = \
              calib.getMagnitude(tmpCat['base_PsfFlux_flux'],
@@ -141,15 +143,15 @@ def loadAndMatchData(repo, visitDataIds,
     return allMatches
 
 
-def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
+def analyzeData(allMatches, safeSnr=50.0, verbose=False):
     """Calculate summary statistics for each star.
 
     Parameters
     ----------
     allMatches : afw.table.GroupView
         GroupView object with matches.
-    good_mag_limit : float, optional
-        Minimum average brightness (in magnitudes) for a star to be considered.
+    safeSnr : float, optional
+        Minimum median SNR for a match to be considered "safe".
     verbose : bool, optional
         Output additional information on the analysis steps.
 
@@ -159,6 +161,7 @@ def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
     - mag: mean PSF magnitude for good matches
     - magerr: median of PSF magnitude for good matches
     - magrms: standard deviation of PSF magnitude for good matches
+    - snr: median PSF flux SNR for good matches
     - dist: RMS RA/Dec separation, in milliarcsecond
     - goodMatches: all good matches, as an afw.table.GroupView;
         good matches contain sources that have a finite (non-nan) PSF magnitude
@@ -172,6 +175,7 @@ def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
                 for flag in ("saturated", "cr", "bad", "edge")]
     nMatchesRequired = 2
 
+    psfSnrKey = allMatches.schema.find("base_PsfFlux_snr").key
     psfMagKey = allMatches.schema.find("base_PsfFlux_mag").key
     psfMagErrKey = allMatches.schema.find("base_PsfFlux_magerr").key
     extendedKey = allMatches.schema.find("base_ClassificationExtendedness_value").key
@@ -188,19 +192,19 @@ def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
 
     goodMatches = allMatches.where(goodFilter)
 
-    # Filter further to a limited range in magnitude and extendedness
+    # Filter further to a limited range in S/N and extendedness
     # to select bright stars.
-    safeMaxMag = good_mag_limit
     safeMaxExtended = 1.0
 
     def safeFilter(cat):
-        psfMag = np.mean(cat.get(psfMagKey))
+        psfSnr = np.median(cat.get(psfSnrKey))
         extended = np.max(cat.get(extendedKey))
-        return psfMag <= safeMaxMag and extended < safeMaxExtended
+        return psfSnr >= safeSnr and extended < safeMaxExtended
 
     safeMatches = goodMatches.where(safeFilter)
 
     # Pass field=psfMagKey so np.mean just gets that as its input
+    goodPsfSnr = goodMatches.aggregate(np.median, field=psfSnrKey)  # SNR
     goodPsfMag = goodMatches.aggregate(np.mean, field=psfMagKey)  # mag
     goodPsfMagRms = goodMatches.aggregate(np.std, field=psfMagKey)  # mag
     goodPsfMagErr = goodMatches.aggregate(np.median, field=psfMagErrKey)
@@ -212,6 +216,7 @@ def analyzeData(allMatches, good_mag_limit=19.5, verbose=False):
         mag = goodPsfMag,
         magerr = goodPsfMagErr,
         magrms = goodPsfMagRms,
+        snr = goodPsfSnr,
         dist = dist,
         goodMatches = goodMatches,
         safeMatches = safeMatches,
@@ -257,7 +262,7 @@ def run(repo, visitDataIds, outputPrefix=None, **kwargs):
         runOneFilter(repo, theseVisitDataIds, outputPrefix=thisOutputPrefix, **kwargs)
 
 
-def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
+def runOneFilter(repo, visitDataIds, brightSnr=100, good_mag_limit=19.5,
         medianAstromscatterRef=25, medianPhotoscatterRef=25, matchRef=500,
         makePrint=True, makePlot=True, makeJson=True,
         outputPrefix=None,
@@ -279,8 +284,8 @@ def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
     visitDataIds : list of dict
         List of `butler` data IDs of Image catalogs to compare to reference.
         The `calexp` cpixel image is needed for the photometric calibration.
-    good_mag_limit : float, optional
-        Minimum average brightness (in magnitudes) for a star to be considered.
+    brightSnr : float, optional
+        Minimum SNR for a star to be considered bright
     medianAstromscatterRef : float, optional
         Expected astrometric RMS [mas] across visits.
     medianPhotoscatterRef : float, optional
@@ -304,7 +309,7 @@ def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
         outputPrefix = repoNameToPrefix(repo)
 
     allMatches = loadAndMatchData(repo, visitDataIds, verbose=verbose)
-    struct = analyzeData(allMatches, good_mag_limit, verbose=verbose)
+    struct = analyzeData(allMatches, brightSnr, verbose=verbose)
     magavg = struct.mag
     magerr = struct.magerr
     magrms = struct.magrms
@@ -315,17 +320,17 @@ def runOneFilter(repo, visitDataIds, good_mag_limit=21.0,
     mmagerr = 1000*magerr
     mmagrms = 1000*magrms
 
-    checkAstrometry(magavg, mmagrms, dist, match,
-                    good_mag_limit=good_mag_limit,
+    checkAstrometry(struct.snr, dist, match,
+                    brightSnr=brightSnr,
                     medianRef=medianAstromscatterRef, matchRef=matchRef)
-    checkPhotometry(magavg, mmagrms, dist, match,
-                    good_mag_limit=good_mag_limit,
+    checkPhotometry(struct.snr, magavg, mmagrms, dist, match,
+                    brightSnr=brightSnr,
                     medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
-        plotAstrometry(magavg, mmagerr, mmagrms, dist, match,
-                       good_mag_limit=good_mag_limit, outputPrefix=outputPrefix)
-        plotPhotometry(magavg, mmagerr, mmagrms, dist, match,
-                       good_mag_limit=good_mag_limit, outputPrefix=outputPrefix)
+        plotAstrometry(struct.snr, mmagrms, dist, match,
+                       brightSnr=brightSnr, outputPrefix=outputPrefix)
+        plotPhotometry(struct.snr, magavg, mmagerr, mmagrms, dist, match,
+                       brightSnr=brightSnr, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key
 

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -333,9 +333,9 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
                     brightSnr=brightSnr,
                     medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
-        plotAstrometry(struct.snr, mmagrms, dist, match,
+        plotAstrometry(dist, magavg, struct.snr,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
-        plotPhotometry(struct.snr, magavg, mmagerr, mmagrms, dist, match,
+        plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key

--- a/tests/runCfht.yaml
+++ b/tests/runCfht.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars bright than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/tests/runCfhtParametersOnly.yaml
+++ b/tests/runCfhtParametersOnly.yaml
@@ -1,7 +1,7 @@
 # Configuration information for validate_drp to 
 #   1. build the list of data IDs to analyze
 #   2. load the default magnitude ranges, expected peformance, and num matches
-good_mag_limit: 21.0  # Only consider stars bright than this limit
+brightSnr: 100  # Only consider stars bright than this limit
 medianAstromscatterRef: 25  # expected astrometric variability [mas]
 medianPhotoscatterRef: 25  # expected photometric variability [mmag]
 matchRef: 5000  # Number of stars expected to match.  Update if you change the ccd list below

--- a/tests/testLoading.py
+++ b/tests/testLoading.py
@@ -48,16 +48,16 @@ class LoadDataTestCase(unittest.TestCase):
         pass
 
     def testLoadingOfConfigFileParameters(self):
-        dataIds, good_mag_limit, \
+        dataIds, brightSnr, \
             medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
                 util.loadDataIdsAndParameters(self.configFile)
-        self.assertAlmostEqual(good_mag_limit, 21.0)
+        self.assertAlmostEqual(brightSnr, 100)
         self.assertAlmostEqual(medianAstromscatterRef, 25)
         self.assertAlmostEqual(medianPhotoscatterRef, 25)
         self.assertAlmostEqual(matchRef, 5000)
 
     def testLoadingOfConfigFileDataIds(self):
-        dataIds, good_mag_limit, \
+        dataIds, brightSnr, \
             medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
                 util.loadDataIdsAndParameters(self.configFile)
         # Tests of the dict entries require constructing and comparing sets
@@ -66,7 +66,7 @@ class LoadDataTestCase(unittest.TestCase):
                          set([d['visit'] for d in dataIds]))
 
     def testLoadingEmptyDataIds(self):
-        dataIds, good_mag_limit, \
+        dataIds, brightSnr, \
             medianAstromscatterRef, medianPhotoscatterRef, matchRef = \
                 util.loadDataIdsAndParameters(self.configFileNoDataIds)
         # Tests of the dict entries require constructing and comparing sets


### PR DESCRIPTION
Use S/N threshold instead of mag threshold to define the "bright" stars to use for the SRD and related calculations.

Plot astrometric RMS vs. SNR and mag.
