### PR TITLE
DM-5660: Add motivated model fits to validate_drp photometric and astrometric scatter/repeatability analysis and plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 Validate an LSST DM processCcd.py output repository
 against a set of LSST Science Requirements Document Key Performance Metrics.
+and expected performance following the LSST Overview paper.
 
 ```
 setup validate_drp
 validateDrp.py CFHT/output
 ```
 
-will produces output, plots, JSON files analyzing the processed data in `CFHT/output`.  Metrics will be separately calculated for each filter represented in the repository.  Replace `CFHT/output` with your favorite processed data repository and you will get reasonable output.
+will produces output, plots, JSON files analyzing the processed data in `CFHT/output`.  Metrics will be separately calculated for each filter represented in the repository.  
+
+Replace `CFHT/output` with your favorite processed data repository and you will get reasonable output.
 
 One can run `validateDrp.py` in any of the following modes:
 1. use no configuration file (as above)
 2. pass a configuration file with just validation parameters (brightSnr, number of expected matches, ...) but no dataId specifications
 3. pass a configuration file that specifies validation parameters and the dataIds to process.  See examples below for use with a `--configFile`
-
-Caveat:  Will likely not successfully run on more than 500 catalogs per band due to memory limits and inefficiencies in the current matching approach.
 
 ------
 This package also includes examples that run processCcd task on some 
@@ -144,6 +145,14 @@ Once these basic steps are completed, then you can run any of the following:
     ```
 
 Note that the example validation test selects several of the CCDs and will fail if you just pass it a repository with 1 visit or just 1 CCD.
+
+Notes
+-----
+* Will likely not successfully run on more than 500 catalogs per band due to memory limits and inefficiencies in the current matching approach.
+* The astrometric and photometric error models are formally valid for individual images.  However, they are being applied here to the results from the set of images, which is implicitly looking at some sort of mean performance.
+E.g., the expected astrometric uncertainty is intimately related to the seeing of the image.  For collections of images where most have a similar seeing, these estimates are useful and reasonable.  However, if the data set analyzed consisted of a set of images distributed across a wide range of seeing values, then the fits here have less direct meaning.
+
+
 
 Files of Interest:
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 Validate an LSST DM processCcd.py output repository
 against a set of LSST Science Requirements Document Key Performance Metrics.
-and expected performance following the LSST Overview paper.
+Also assess expected analytic models for photometric and astrometric performance following the LSST Overview paper.
 
 ```
 setup validate_drp
 validateDrp.py CFHT/output
 ```
 
-will produces output, plots, JSON files analyzing the processed data in `CFHT/output`.  Metrics will be separately calculated for each filter represented in the repository.  
+will produce output, plots, JSON files analyzing the processed data in `CFHT/output`.  Metrics will be separately calculated for each filter represented in the repository.
 
 Replace `CFHT/output` with your favorite processed data repository and you will get reasonable output.
 
 One can run `validateDrp.py` in any of the following modes:
+
 1. use no configuration file (as above)
 2. pass a configuration file with just validation parameters (brightSnr, number of expected matches, ...) but no dataId specifications
 3. pass a configuration file that specifies validation parameters and the dataIds to process.  See examples below for use with a `--configFile`
 
 ------
-This package also includes examples that run processCcd task on some 
+This package also includes examples that run processCcd task on some
 CFHT data and DECam data
 and validate the astrometric and photometric repeatability of the results.
 
@@ -45,7 +46,7 @@ rebuild -u obs_decam obs_cfht validation_data_decam validation_data_cfht validat
 To setup for a run with CFHT:
 ```
 setup pipe_tasks
-setup obs_cfht 
+setup obs_cfht
 setup validation_data_cfht
 setup validate_drp
 ```

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -155,8 +155,10 @@ def checkAstrometry(snr, dist, match,
     Returns
     -------
     pipeBase.Struct
+        name -- str: "checkAstrometry"
         astromScatter -- float: The astrometric scatter (RMS, milliarcsec) for all good stars.
-        astromFitParams -- list or numpy.array of float:  Fit parameters.
+        astromErrModel -- str: Description of astrometric error model
+        astromErrFitParams -- list or numpy.array of float:  Fit parameters.
 
     Notes
     -----
@@ -181,8 +183,10 @@ def checkAstrometry(snr, dist, match,
     if match < matchRef:
         print("Number of matched sources %d is too small (shoud be > %d)" % (match, matchRef))
 
-    return pipeBase.Struct(astromScatter=astromScatter, 
-                           astromFitParams=fit_params)
+    return pipeBase.Struct(name="checkAstrometry",
+                           astromRmsScatter=astromScatter, 
+                           astromErrModel=astromErrModel.__doc__,
+                           astromErrFitParams=fit_params)
 
 
 def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
@@ -214,6 +218,7 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
     Returns
     -------
     pipeBase.Struct
+        name -- str: "checkPhotometry"
         photScatter -- float: The photometric scatter (RMS, mmag) for all good star stars.
         photFitParams -- list or numpy.array of float:  Fit parameters.
 
@@ -241,8 +246,10 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
         print("Number of matched sources %d is too small (shoud be > %d)"
               % (match, matchRef))
 
-    return pipeBase.Struct(photScatter=photScatter, 
-                           photFitParams=fit_params)
+    return pipeBase.Struct(name="checkPhotometry",
+                           photRmsScatter=photScatter, 
+                           photErrModel=photErrModel.__doc__,
+                           photErrFitParams=fit_params)
 
 
 def astromErrModel(snr, theta=1, sigma_sys=0.01, C=1):

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -77,6 +77,16 @@ def fitExp(x, y, y_err, deg=2):
 
 
 def fitAstromErrModel(snr, dist):
+    """Fit model of astrometric error from LSST Overview paper
+
+    Parameters
+    ----------
+    snr : list or numpy.array
+        Signal-to-noise ratio of photometric observations
+    dist : list or numpy.array
+        Scatter in measured positions [mas]
+
+def fitAstromErrModel(snr, dist):
     fit_params, fit_param_covariance = \
         curve_fit(astromErrModel, snr, dist, p0=[1, 0.01])
 
@@ -206,7 +216,7 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
         Average magnitudes of each star.  [mag]
     mmagErr : list or numpy.array
         Uncertainties in magnitudes of each star.  [mmag]
-    mmagrms ; list or numpy.array
+    mmagrms : list or numpy.array
         Magnitude RMS of the multiple observation of each star. [mmag]
     dist : list or numpy.array
         Distances between successive measurements of one star
@@ -260,33 +270,37 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
                            photRmsScatter=photScatter)
 
 
-def astromErrModel(snr, theta=1, sigmaSys=0.01, C=1):
+def astromErrModel(snr, theta=1000, sigmaSys=10, C=1, **kwargs):
     """Calculate expected astrometric uncertainty based on SNR.
 
-    mas = C*theta/SNR
+    mas = C*theta/SNR + sigmaSys
 
     Parameters
     ----------
     snr : list or numpy.array
         S/N of photometric measurements
     theta : float or numpy.array, optional
-        Seeing [mas]
+        Seeing
     sigmaSys : float
-        Systematic error floor [mas]
+        Systematic error floor
     C : float
         Scaling factor
-    verbose : bool, optional
-        Produce extra output to STDOUT
+
+    theta and sigmaSys must be given in the same units.  
+    Typically choices might be any of arcsec, milli-arcsec, or radians
+    The default values are reasonable astronominal values in milliarcsec.
+    But the only thing that matters is that they're the same.
 
     Returns
     -------
     np.array
-        Expected astrometric uncertainty. [mas]
+        Expected astrometric uncertainty.
+        Units will be those of theta + sigmaSys.
     """
     return C*theta/snr + sigmaSys
 
 
-def photErrModel(mag, sigmaSys, gamma, m5):
+def photErrModel(mag, sigmaSys, gamma, m5, **kwargs):
     """Fit model of photometric error from LSST Overview paper
     http://arxiv.org/abs/0805.2366v4
 
@@ -295,7 +309,7 @@ def photErrModel(mag, sigmaSys, gamma, m5):
     sigma_1^2 = sigma_sys^2 + sigma_rand^2
 
     Eq. 5
-    sigma_(rand) = (0.04 - gamma) * x + gamma * x^2 [mag^2]
+    sigma_rand^2 = (0.04 - gamma) * x + gamma * x^2 [mag^2]
     where x = 10**(0.4*(m-m_5))
 
     Parameters

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -86,11 +86,16 @@ def fitAstromErrModel(snr, dist):
     dist : list or numpy.array
         Scatter in measured positions [mas]
 
-def fitAstromErrModel(snr, dist):
+    Returns
+    -------
+    dict
+        The fit results for C, theta, sigmaSys along with their Units.
+    """
     fit_params, fit_param_covariance = \
         curve_fit(astromErrModel, snr, dist, p0=[1, 0.01])
 
-    params = {'C': 1, 'theta': fit_params[0], 'sigmaSys': fit_params[1]}
+    params = {'C': 1, 'theta': fit_params[0], 'sigmaSys': fit_params[1],
+              'cUnits': '', 'thetaUnits': 'mas', 'sigmaSysUnits': 'mas'}
     return params
 
 
@@ -106,14 +111,16 @@ def fitPhotErrModel(mag, mmag_err):
 
     Returns
     -------
-    float, float, float
-        sigmaSys, gamma, m5 fit parameters.
+    dict
+        The fit results for sigmaSys, gamma, and m5 along with their Units.
     """
     mag_err = mmag_err / 1000
     fit_params, fit_param_covariance = \
         curve_fit(photErrModel, mag, mag_err, p0=[0.01, 0.039, 24.35])
 
-    return dict(zip(('sigmaSys', 'gamma', 'm5'), fit_params))
+    params = {'sigmaSys': fit_params[0], 'gamma': fit_params[1], 'm5': fit_params[2],
+              'sigmaSysUnits': 'mmag', 'gammaUnits': '', 'm5Units': 'mag'}
+    return params
 
 
 def positionRms(cat):

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -24,6 +24,7 @@ import numpy as np
 from scipy.optimize import curve_fit
 
 import lsst.afw.geom as afwGeom
+import lsst.pipe.base as pipeBase
 
 from .util import averageRaDecFromCat
 
@@ -153,8 +154,9 @@ def checkAstrometry(snr, dist, match,
 
     Returns
     -------
-    float
-        The astrometric scatter (RMS, milliarcsec) for all good stars.
+    pipeBase.Struct
+        astromScatter -- float: The astrometric scatter (RMS, milliarcsec) for all good stars.
+        astromFitParams -- list or numpy.array of float:  Fit parameters.
 
     Notes
     -----
@@ -179,7 +181,8 @@ def checkAstrometry(snr, dist, match,
     if match < matchRef:
         print("Number of matched sources %d is too small (shoud be > %d)" % (match, matchRef))
 
-    return astromScatter, fit_params
+    return pipeBase.Struct(astromScatter=astromScatter, 
+                           astromFitParams=fit_params)
 
 
 def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
@@ -210,8 +213,9 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
 
     Returns
     -------
-    float
-        The photometry scatter (RMS, millimag) for all good stars.
+    pipeBase.Struct
+        photScatter -- float: The photometric scatter (RMS, mmag) for all good star stars.
+        photFitParams -- list or numpy.array of float:  Fit parameters.
 
     Notes
     -----
@@ -224,20 +228,21 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
           (np.median(mmagrms), "mmag"))
 
     bright = np.where(np.asarray(snr) > brightSnr)
-    photoScatter = np.median(np.asarray(mmagrms)[bright])
+    photScatter = np.median(np.asarray(mmagrms)[bright])
     print("Photometric scatter (median) - SNR > %.1f : %.1f %s" %
-          (brightSnr, photoScatter, "mmag"))
+          (brightSnr, photScatter, "mmag"))
 
     fit_params = fitPhotErrModel(mag[bright], mmagErr[bright])
 
-    if photoScatter > medianRef:
+    if photScatter > medianRef:
         print("Median photometric scatter %.3f %s is larger than reference : %.3f %s "
-              % (photoScatter, "mmag", medianRef, "mag"))
+              % (photScatter, "mmag", medianRef, "mag"))
     if match < matchRef:
         print("Number of matched sources %d is too small (shoud be > %d)"
               % (match, matchRef))
 
-    return photoScatter, fit_params
+    return pipeBase.Struct(photScatter=photScatter, 
+                           photFitParams=fit_params)
 
 
 def astromErrModel(snr, theta=1, sigma_sys=0.01, C=1):

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -185,7 +185,7 @@ def checkAstrometry(snr, dist, match,
         model_name -- str: "astromErrModel"
         doc -- str: Description of astrometric error model
         params -- dict: Fit parameters as "name": value.
-        astromRmsScatter -- float: 
+        astromRmsScatter -- float:
            The astrometric scatter (RMS, milliarcsec) for all good stars.
 
     Notes
@@ -215,7 +215,7 @@ def checkAstrometry(snr, dist, match,
                            model_name="astromErrModel",
                            doc=astromErrModel.__doc__,
                            params=fit_params,
-                           astromRmsScatter=astromScatter) 
+                           astromRmsScatter=astromScatter)
 
 
 def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
@@ -251,7 +251,7 @@ def checkPhotometry(snr, mag, mmagErr, mmagrms, dist, match,
         model_name -- str:  "photErrModel"
         doc -- str: Description of photometric error model
         params -- dict: Fit parameters as "name": value.
-        photRmsScatter -- float: 
+        photRmsScatter -- float:
             The photometric scatter (RMS, mmag) for all good star stars.
 
     Notes
@@ -301,7 +301,7 @@ def astromErrModel(snr, theta=1000, sigmaSys=10, C=1, **kwargs):
     C : float
         Scaling factor
 
-    theta and sigmaSys must be given in the same units.  
+    theta and sigmaSys must be given in the same units.
     Typically choices might be any of arcsec, milli-arcsec, or radians
     The default values are reasonable astronominal values in milliarcsec.
     But the only thing that matters is that they're the same.

--- a/python/lsst/validate/drp/check.py
+++ b/python/lsst/validate/drp/check.py
@@ -67,6 +67,14 @@ def magNormDiff(cat):
     return normDiff
 
 
+def expModel(x, a, b, norm):
+    return a * np.exp(x/norm) + b
+
+
+def magerrModel(x, a, b):
+    return expModel(x, a, b, norm=5)
+
+
 def fitExp(x, y, y_err, deg=2):
     """Fit an exponential quadratic to x, y, y_err.
     """

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -201,10 +201,9 @@ def plotAstromErrModelFit(snr, dist, fit_params=None,
         fit_params = fitAstromErrModel(snr, dist)
 
     x_model = np.logspace(np.log10(xlim[0]), np.log10(xlim[1]), num=100)
-    fit_model_mas_err = astromErrModel(x_model, *fit_params)
-    C_theta, sigma_sys = fit_params
-    label = r'$C\theta$, $\sigma_{\rm sys}$ =' + '\n' + \
-            '%.4g, %.4g [mas]' % (C_theta, sigma_sys)
+    fit_model_mas_err = astromErrModel(x_model, **fit_params)
+    label = r'$C, \theta, \sigma_{\rm sys}$ =' + '\n' + \
+            '{C:.2g}, {theta:.4g}, {sigmaSys:.4g} [mas]'.format(**fit_params)
 
     if verbose:
         print(fit_params)
@@ -244,12 +243,13 @@ def plotPhotErrModelFit(mag, mmag_err, fit_params=None, color='red', ax=None, ve
         fit_params = fitPhotErrModel(mag, mmag_err)
 
     x_model = np.linspace(*xlim, num=100)
-    fit_model_mag_err = photErrModel(x_model, *fit_params)
+    fit_model_mag_err = photErrModel(x_model, **fit_params)
     fit_model_mmag_err = 1000*fit_model_mag_err
-    sigmaSysMmag, gamma, m5Mag = fit_params[:]
-    labelFormatStr = r'$\sigma_{\rm sys} {\rm [mmag]}$, $\gamma$, $m_5 {\rm [mag]}$=' + '\n' + \
-                     r'%6.4f, %6.4f, %6.3f' 
-    label = labelFormatStr % (1000*sigmaSysMmag, gamma, m5Mag)
+    labelFormatStr = r'$\sigma_{{\rm sys}} {{\rm [mmag]}}$, $\gamma$, $m_5 {{\rm [mag]}}$=' + '\n' + \
+                     r'{sigmaSysMmag:6.4f}, {gamma:6.4f}, {m5:6.3f}' 
+    print("FIT_PARAMS: ", fit_params)
+    label = labelFormatStr.format(sigmaSysMmag=1000*fit_params['sigmaSys'],
+                                  **fit_params)
 
     if verbose:
         print(fit_params)

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -23,7 +23,7 @@ from __future__ import print_function, division
 import matplotlib.pylab as plt
 import numpy as np
 import scipy.stats
-from .check import fitExp, fitAstromErrModel, fitPhotErrModel, astromErrModel, photErrModel
+from .check import fitExp, fitAstromErrModel, fitPhotErrModel, expModel, astromErrModel, photErrModel
 
 # Plotting defaults
 plt.rcParams['axes.linewidth'] = 2
@@ -130,14 +130,6 @@ def plotAstrometry(dist, mag, snr, fit_params=None, brightSnr=100,
     plotPath = outputPrefix+"check_astrometry.png"
     plt.savefig(plotPath, format="png")
     plt.close(fig)
-
-
-def expModel(x, a, b, norm):
-    return a * np.exp(x/norm) + b
-
-
-def magerrModel(x, a, b):
-    return expModel(x, a, b, norm=5)
 
 
 def plotExpFit(x, y, y_err, fit_params=None, deg=2, ax=None, verbose=False):

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -181,6 +181,22 @@ def photErrModel(mag, sigmaSys, gamma, m5):
     Eq. 5
     sigma_(rand) = (0.04 - gamma) * x + gamma * x^2 [mag^2]
     where x = 10**(0.4*(m-m_5))
+
+    Parameters
+    ----------
+    mag : list or numpy.array
+        Magnitude
+    sigmaSq : float
+        Limiting systematics floor [mag]
+    gamma : float
+        proxy for sky brightness and readout noise
+    m5 : float
+        5-sigma depth [mag]
+
+    Returns
+    -------
+    numpy.array
+        Result of noise estimation function
     """
     x = 10**(0.4*(mag - m5))
     sigmaRandSq = (0.04 - gamma) * x + gamma * x**2
@@ -191,6 +207,21 @@ def photErrModel(mag, sigmaSys, gamma, m5):
 def plotPhotErrModelFit(mag, mmag_err, ax=None, verbose=True):
     """Fit and plot model of photometric error from LSST Overview paper
 
+    Parameters
+    ----------
+    mag : list or numpy.array
+        Magnitude
+    mag_err : list or numpy.array
+        Magnitude uncertainty or variation in *mmag*.
+    ax : matplotlib.Axis, optional
+        The Axis object to plot to.
+    verbose : bool, optional
+        Produce extra output to STDOUT
+
+    Returns
+    -------
+    float, float, float
+        sigmaSys, gamma, m5 fit parameters.
     """
 
     if ax is None:
@@ -208,7 +239,6 @@ def plotPhotErrModelFit(mag, mmag_err, ax=None, verbose=True):
     sigmaSysMmag, gamma, m5Mag = fit_params[:]
     label = r'$\sigma_{\rm sys\ mmag}$=%5.2f, $\gamma=$%6.4f, $m_5=$%6.3f mag' % \
         (1000*sigmaSysMmag, gamma, m5Mag) 
-    tuple(fit_params)
 
     if verbose:
         print(fit_params)

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -163,7 +163,7 @@ def plotExpFit(x, y, y_err, fit_params=None, deg=2, ax=None, verbose=False):
             label=label)
 
 
-def plotAstromErrModelFit(snr, dist, fit_params=None, 
+def plotAstromErrModelFit(snr, dist, fit_params=None,
                           color='red', ax=None, verbose=True):
     """Plot model of photometric error from LSST Overview paper
     http://arxiv.org/abs/0805.2366v4
@@ -177,11 +177,6 @@ def plotAstromErrModelFit(snr, dist, fit_params=None,
         S/N of photometric measurements
     dist : list or numpy.array
         Separation from reference [mas]
-
-    Returns
-    -------
-    float
-        C*theta
     """
     if ax is None:
         ax = plt.figure()
@@ -209,7 +204,7 @@ def plotAstromErrModelFit(snr, dist, fit_params=None,
 
 
 def plotPhotErrModelFit(mag, mmag_err, fit_params=None, color='red', ax=None, verbose=True):
-    """plot model of photometric error from LSST Overview paper
+    """Plot model of photometric error from LSST Overview paper (Eq. 4 & 5)
 
     Parameters
     ----------
@@ -238,8 +233,7 @@ def plotPhotErrModelFit(mag, mmag_err, fit_params=None, color='red', ax=None, ve
     fit_model_mag_err = photErrModel(x_model, **fit_params)
     fit_model_mmag_err = 1000*fit_model_mag_err
     labelFormatStr = r'$\sigma_{{\rm sys}} {{\rm [mmag]}}$, $\gamma$, $m_5 {{\rm [mag]}}$=' + '\n' + \
-                     r'{sigmaSysMmag:6.4f}, {gamma:6.4f}, {m5:6.3f}' 
-    print("FIT_PARAMS: ", fit_params)
+                     r'{sigmaSysMmag:6.4f}, {gamma:6.4f}, {m5:6.3f}'
     label = labelFormatStr.format(sigmaSysMmag=1000*fit_params['sigmaSys'],
                                   **fit_params)
 
@@ -247,7 +241,7 @@ def plotPhotErrModelFit(mag, mmag_err, fit_params=None, color='red', ax=None, ve
         print(fit_params)
         print(label)
 
-    ax.plot(x_model, fit_model_mmag_err, 
+    ax.plot(x_model, fit_model_mmag_err,
             color=color, linewidth=2,
             label=label)
 

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -191,7 +191,7 @@ def loadDataIdsAndParameters(configFile):
         dataIds = constructDataIds(parameters['filter'], parameters['visits'],
                                    parameters[ccdKeyName], ccdKeyName)
     except KeyError:
-        # If the above parameters are not in the `parameters` dict, 
+        # If the above parameters are not in the `parameters` dict,
         # presumably because they were not in the configFile
         # then we return no dataIds.
         dataIds = []

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -528,16 +528,20 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
     mmagerr = 1000*magerr
     mmagrms = 1000*magrms
 
-    checkAstrometry(struct.snr, dist, match,
-                    brightSnr=brightSnr,
-                    medianRef=medianAstromscatterRef, matchRef=matchRef)
-    checkPhotometry(struct.snr, magavg, mmagrms, dist, match,
-                    brightSnr=brightSnr,
-                    medianRef=medianPhotoscatterRef, matchRef=matchRef)
+    astromScatter, astromFitParams = \
+        checkAstrometry(struct.snr, dist, match,
+                        brightSnr=brightSnr,
+                        medianRef=medianAstromscatterRef, matchRef=matchRef)
+    photScatter, photFitParams = \
+        checkPhotometry(struct.snr, magavg, mmagerr, mmagrms, dist, match,
+                        brightSnr=brightSnr,
+                        medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
         plotAstrometry(dist, magavg, struct.snr,
+                       fit_params=astromFitParams,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
         plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
+                       fit_params=photFitParams,
                        brightSnr=brightSnr, filterName=filterName, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -538,10 +538,10 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
                         medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
         plotAstrometry(dist, magavg, struct.snr,
-                       fit_params=astromStruct.astromFitParams,
+                       fit_params=astromStruct.astromErrFitParams,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
         plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
-                       fit_params=photStruct.photFitParams,
+                       fit_params=photStruct.photErrFitParams,
                        brightSnr=brightSnr, filterName=filterName, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key
@@ -568,9 +568,8 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
                 plotAMx(metric, outputPrefix=outputPrefix)
 
     if makeJson:
-        for name, struct in zip(("check_astrometry", "check_photometry"),
-                                (astromStruct, photStruct)):
-            outfile = outputPrefix + "%s.json" % name
+        for struct in (astromStruct, photStruct):
+            outfile = outputPrefix + "%s.json" % struct.name
             saveKpmToJson(struct, outfile)
 
         for metric in (AM1, AM2, AM3, PA1, PA2):

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -538,10 +538,10 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
                         medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
         plotAstrometry(dist, magavg, struct.snr,
-                       fit_params=astromStruct.astromErrFitParams,
+                       fit_params=astromStruct.params,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
         plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
-                       fit_params=photStruct.photErrFitParams,
+                       fit_params=photStruct.params,
                        brightSnr=brightSnr, filterName=filterName, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -514,6 +514,7 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
     if outputPrefix is None:
         outputPrefix = repoNameToPrefix(repo)
 
+    filterName = set([dId['filter'] for dId in visitDataIds]).pop()
     allMatches = loadAndMatchData(repo, visitDataIds, verbose=verbose)
     struct = analyzeData(allMatches, brightSnr, verbose=verbose)
 
@@ -537,7 +538,7 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
         plotAstrometry(dist, magavg, struct.snr,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
         plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
-                       brightSnr=brightSnr, outputPrefix=outputPrefix)
+                       brightSnr=brightSnr, filterName=filterName, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key
 

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -528,20 +528,20 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
     mmagerr = 1000*magerr
     mmagrms = 1000*magrms
 
-    astromScatter, astromFitParams = \
+    astromStruct = \
         checkAstrometry(struct.snr, dist, match,
                         brightSnr=brightSnr,
                         medianRef=medianAstromscatterRef, matchRef=matchRef)
-    photScatter, photFitParams = \
+    photStruct = \
         checkPhotometry(struct.snr, magavg, mmagerr, mmagrms, dist, match,
                         brightSnr=brightSnr,
                         medianRef=medianPhotoscatterRef, matchRef=matchRef)
     if makePlot:
         plotAstrometry(dist, magavg, struct.snr,
-                       fit_params=astromFitParams,
+                       fit_params=astromStruct.astromFitParams,
                        brightSnr=brightSnr, outputPrefix=outputPrefix)
         plotPhotometry(magavg, struct.snr, mmagerr, mmagrms,
-                       fit_params=photFitParams,
+                       fit_params=photStruct.photFitParams,
                        brightSnr=brightSnr, filterName=filterName, outputPrefix=outputPrefix)
 
     magKey = allMatches.schema.find("base_PsfFlux_mag").key

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -568,6 +568,11 @@ def runOneFilter(repo, visitDataIds, brightSnr=100,
                 plotAMx(metric, outputPrefix=outputPrefix)
 
     if makeJson:
+        for name, struct in zip(("check_astrometry", "check_photometry"),
+                                (astromStruct, photStruct)):
+            outfile = outputPrefix + "%s.json" % name
+            saveKpmToJson(struct, outfile)
+
         for metric in (AM1, AM2, AM3, PA1, PA2):
             if metric:
                 outfile = outputPrefix + "%s.json" % metric.name

--- a/ups/validate_drp.table
+++ b/ups/validate_drp.table
@@ -4,6 +4,9 @@ setupRequired(afw)
 setupRequired(pipe_base)
 setupRequired(pyyaml)
 
+setupRequired(scipy)
+setupRequired(matplotlib)
+
 setupOptional(pipe_tasks)
 setupOptional(obs_cfht)
 setupOptional(obs_decam)


### PR DESCRIPTION
Implements well-motivated theoretical fits to the astrometric and photometric performance measurements based on derivations from LSST Overview paper.
http://arxiv.org/pdf/0805.2366v4.pdf
Photometric errors described by
Eq. 5
sigma_(rand) = (0.039 - gamma) \* x + gamma \* x^2 [mag^2]
where x = 10^(0.4*(m-m_5))
Eq. 4
sigma_1^2 = sigma_sys^2 + sigma_rand^2
Astrometric Errors 
error = C \* theta / SNR
Based on helpful comments from Zeljko Ivezic
"""
I think eq. 5 from the overview paper (with gamma = 0.039 and m5 = 24.35;
the former I assumed and the latter I got from the value of your 
analytic fit that gives err=0.2 mag) would be a much better fit than
the adopted function for mag < 21 (and it is derived from first principles). 
Actually, if you fit for the systematic term (eq. 4) and gamma and m5,
it would be a nice check whether there is any “weird” behavior in 
analyzed data (and you get the limiting depth, m5, even if you don’t
go all the way to the faint end).
Similarly, for the astrometric random errors, we’d expect 
error = C \* theta / SNR,
where theta is the seeing (or a fit parameter), SNR is the photometric
SNR (i.e. 1/err in mag), and C ~ 1 (empirically, and 0.6 for the idealized
maximum likelihood solution and gaussian seeing). 
"""
