### PR TITLE
DM-6318 Update bin.src/validate_drp.py to handle missing "requirements" gracefully.

### DIFF
--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     validate.run(args.repo, **kwargs)
 
     # Only check against expectations if we were passed information about those expectations
-    if args.configFile and kwargs['requirements']:
+    if args.configFile and 'requirements' in kwargs:
         kpm_verbose = True
         level = 'design'
         if kpm_verbose:


### PR DESCRIPTION
The check for 'requirements' being specified in the configuration file
was in error.  Now correctly checks to see if 'requirements' is a key
in 'kwargs'.
