### PR TITLE
DM-7577: Redirect log to a file instead of using "--logdest"

### DIFF
--- a/examples/runExample.sh
+++ b/examples/runExample.sh
@@ -81,9 +81,9 @@ makeRunList.py "${YAMLCONFIG}" > "${RUNLIST}"
 
 ${PROCESSCCD} "${INPUT}" --output "${OUTPUT}" \
     @"${RUNLIST}" \
-    --logdest "${WORKSPACE}"/processCcd.log \
     --configfile "${CONFIG_FILE}" \
-    -j $NUMPROC
+    -j $NUMPROC \
+    >& "${WORKSPACE}"/processCcd.log
 
 # Run astrometry check on src
 echo "validating"


### PR DESCRIPTION
Per RFC-203, the CmdLineTask argument "--logdest" has been removed.
