### PR TITLE
DM-7328: Port validate_drp to Python 3

### DIFF
--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -19,6 +19,8 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 
 from __future__ import print_function, absolute_import
+from builtins import zip
+from builtins import range
 
 import numpy as np
 import astropy.units as u

--- a/python/lsst/validate/drp/calcsrd/pa1.py
+++ b/python/lsst/validate/drp/calcsrd/pa1.py
@@ -19,6 +19,7 @@
 # see <https://www.lsstcorp.org/LegalNotices/>.
 
 from __future__ import print_function, absolute_import
+from builtins import range
 
 import math
 

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -20,6 +20,8 @@
 """Miscellaneous functions to support lsst.validate.drp."""
 
 from __future__ import print_function, division
+from builtins import zip
+from past.builtins import basestring
 
 import os
 
@@ -216,7 +218,7 @@ def constructDataIds(filters, visits, ccds, ccdKeyName='ccd'):
     >>> print(dataIds)
     [{'filter': 'r', 'visit': 100, 'ccd': 10}, {'filter': 'r', 'visit': 100, 'ccd': 11}, {'filter': 'r', 'visit': 100, 'ccd': 12}, {'filter': 'r', 'visit': 200, 'ccd': 10}, {'filter': 'r', 'visit': 200, 'ccd': 11}, {'filter': 'r', 'visit': 200, 'ccd': 12}]
     """
-    if isinstance(filters, str):
+    if isinstance(filters, basestring):
         filters = [filters for _ in visits]
 
     assert len(filters) == len(visits)

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -22,6 +22,7 @@ grading, and persistence.
 """
 
 from __future__ import print_function, absolute_import
+from builtins import object
 
 from textwrap import TextWrapper
 
@@ -40,7 +41,7 @@ from .plot import (plotAMx, plotPA1, plotPhotometryErrorModel,
 __all__ = ['run', 'runOneFilter']
 
 
-class bcolors:
+class bcolors(object):
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'

--- a/ups/validate_drp.table
+++ b/ups/validate_drp.table
@@ -1,3 +1,6 @@
+setupRequired(python)
+setupRequired(python_future)
+
 setupRequired(utils)
 setupRequired(daf_persistence)
 setupRequired(afw)


### PR DESCRIPTION
This PR enables Python 2+3 cross-compatibility for `validate_drp` using futurize.

- [x] Remove the metrics.yaml move commit (https://jira.lsstcorp.org/browse/DM-8558)
- [x] Test against fixed afw (https://jira.lsstcorp.org/browse/DM-8557)
- [x] Verified that `$VALIDATE_DRP_DIR/examples/runCfhtTest.sh` works.