### PR TITLE
DM-9588: "validate_drp broken on cfht/hsc datasets"

### DIFF
--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -321,7 +321,7 @@ def matchVisitComputeDistance(visit_obj1, ra_obj1, dec_obj1,
     j_raw = 0
     j = visit_obj2_idx[j_raw]
     for i in visit_obj1_idx:
-        while (visit_obj2[j] < visit_obj1[i]) and (j_raw < len(visit_obj2_idx)):
+        while (visit_obj2[j] < visit_obj1[i]) and (j_raw < len(visit_obj2_idx)-1):
             j_raw += 1
             j = visit_obj2_idx[j_raw]
         if visit_obj2[j] == visit_obj1[i]:

--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -20,7 +20,6 @@
 
 from __future__ import print_function, absolute_import
 from builtins import zip
-from builtins import range
 
 import numpy as np
 import astropy.units as u

--- a/python/lsst/validate/drp/matchreduce.py
+++ b/python/lsst/validate/drp/matchreduce.py
@@ -226,7 +226,7 @@ class MatchedMultiVisitDataset(BlobBase):
 
             calib = afwImage.Calib(calexpMetadata)
 
-            oldSrc = butler.get('src', vId, immediate=True, flags=SOURCE_IO_NO_FOOTPRINTS)
+            oldSrc = butler.get('src', vId, immediate=True)
             print(len(oldSrc), "sources in ccd %s  visit %s" %
                   (vId[ccdKeyName], vId["visit"]))
 


### PR DESCRIPTION
Fix up DM-5819
1. Fix indexing check error.
2. Remove `flags=SOURCE_NO_IO_FOOTPRINTS` because it only works in `obs_subaru` and fails loudly for other cameras.