### PR TITLE
Add config options for HSC to explicitly use astrometry_net

### DIFF
--- a/config/hscConfig.py
+++ b/config/hscConfig.py
@@ -1,4 +1,7 @@
-# Configure to force using astrometry_net instead of pre-loaded reference catalogs
+"""
+Configure to force using astrometry_net instead of directly 
+loading Pan-STARRS1 reference catalogs
+"""
 
 from lsst.pipe.tasks.setConfigFromEups import setPhotocalConfigFromEups, setAstrometryConfigFromEups
 

--- a/config/hscConfig.py
+++ b/config/hscConfig.py
@@ -1,0 +1,19 @@
+# Configure to force using astrometry_net instead of pre-loaded reference catalogs
+
+from lsst.pipe.tasks.setConfigFromEups import setPhotocalConfigFromEups, setAstrometryConfigFromEups
+
+
+from lsst.meas.astrom import LoadAstrometryNetObjectsTask
+config.processCcd.calibrate.astromRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
+config.processCcd.calibrate.photoRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
+
+setPhotocalConfigFromEups(config.processCcd.calibrate.photoCal)
+
+menu = { "ps1*": {}, # No changes
+         "sdss*": { "filterMap": {"y": "z"} }, # No y-band, use z instead
+         "2mass*": { "filterMap": {ff:"J" for ff in 'grizy'} }, # No optical; use J 
+       }
+
+setAstrometryConfigFromEups(config.processCcd.calibrate.astromRefObjLoader, menu)
+
+

--- a/examples/runHscTest.sh
+++ b/examples/runHscTest.sh
@@ -24,6 +24,7 @@ PRODUCT_DIR="${VALIDATE_DRP_DIR}"
 
 CAMERA=Hsc
 YAMLCONFIG="${PRODUCT_DIR}"/examples/"${CAMERA}".yaml
+CONFIG_FILE="${PRODUCT_DIR}"/config/hscConfig.py
 
 DATA_DIR=${VALIDATION_DATA_HSC_DIR}
 CALIB_DIR=${DATA_DIR}/CALIB
@@ -37,7 +38,7 @@ ingestImages.py "${REPO}" --mode=link "${VALIDATION_DATA_HSC_DIR}"/'raw/*.fits'
 ALL_VISITS=903332^903340^903982^904006^904350^904378^904828^904846
 
 # Heavy lifting
-singleFrameDriver.py ${REPO} --calib "${CALIB_DIR}" --rerun ${RERUN} --job singleFrame --cores ${NUMPROC} --id visit=${ALL_VISITS}
+singleFrameDriver.py ${REPO} --calib "${CALIB_DIR}" --rerun ${RERUN} --job singleFrame --cores ${NUMPROC} --id visit=${ALL_VISITS} -C "${CONFIG_FILE}"
 makeDiscreteSkyMap.py ${REPO} --rerun ${RERUN} --id ccd=0..103 visit=${ALL_VISITS}
 # makeDiscreteSkyMap INFO: tract 0 has corners (321.714, -1.294), (318.915, -1.294), (318.915, 1.504), (321.714, 1.504) (RA, Dec deg) and 15 x 15 patches
 


### PR DESCRIPTION
Because `validation_data_hsc` does not have astrometry files to load, this forces `SingleFrameDriver` to use astrometry_net to process the HSC validation data.  The new config options seem to load OK now, but I haven't been able to run a successful test yet, possibly because the version of `validation_data_hsc` I'm trying to use on `tiger` is old, and because `w_2017_12` is not available on `lsst-dev`.  So @wmwv if you can test this out to see if this fixes DM-9909 that would be great.