### PR TITLE
DM-9829: Catch NoResults when processed data unavailable.

### DIFF
--- a/python/lsst/validate/drp/matchreduce.py
+++ b/python/lsst/validate/drp/matchreduce.py
@@ -31,12 +31,11 @@ import lsst.afw.image as afwImage
 import lsst.afw.image.utils as afwImageUtils
 import lsst.daf.persistence as dafPersist
 from lsst.afw.table import (SourceCatalog, SchemaMapper, Field,
-                            MultiMatch, SimpleRecord, GroupView, SOURCE_IO_NO_FOOTPRINTS)
+                            MultiMatch, SimpleRecord, GroupView)
 from lsst.afw.fits import FitsError
 from lsst.validate.base import BlobBase
 
-from .util import (averageRaDecFromCat, getCcdKeyName, positionRmsFromCat,
-                   sphDist)
+from .util import getCcdKeyName, positionRmsFromCat
 
 
 __all__ = ['MatchedMultiVisitDataset']

--- a/python/lsst/validate/drp/matchreduce.py
+++ b/python/lsst/validate/drp/matchreduce.py
@@ -32,7 +32,7 @@ import lsst.afw.image.utils as afwImageUtils
 import lsst.daf.persistence as dafPersist
 from lsst.afw.table import (SourceCatalog, SchemaMapper, Field,
                             MultiMatch, SimpleRecord, GroupView, SOURCE_IO_NO_FOOTPRINTS)
-from lsst.afw.fits.fitsLib import FitsError
+from lsst.afw.fits import FitsError
 from lsst.validate.base import BlobBase
 
 from .util import (averageRaDecFromCat, getCcdKeyName, positionRmsFromCat,
@@ -206,8 +206,8 @@ class MatchedMultiVisitDataset(BlobBase):
         for vId in dataIds:
             try:
                 calexpMetadata = butler.get("calexp_md", vId, immediate=True)
-            except FitsError as fe:
-                print(fe)
+            except (FitsError, dafPersist.NoResults) as e:
+                print(e)
                 print("Could not open calibrated image file for ", vId)
                 print("Skipping %s " % repr(vId))
                 continue


### PR DESCRIPTION
In DM-8686 the way the Butler looks up data in parent repositories changed,
causing it to throw NoResults (rather than FitsError) when attempting to
retrieve data which wasn't properly processed. Here, we handle both
eventualities.