### PR TITLE
Load astrometry.net from lsst.meas.extensions.astrometryNet.

### DIFF
--- a/config/hscConfig.py
+++ b/config/hscConfig.py
@@ -6,7 +6,7 @@ loading Pan-STARRS1 reference catalogs
 from lsst.pipe.tasks.setConfigFromEups import setPhotocalConfigFromEups, setAstrometryConfigFromEups
 
 
-from lsst.meas.astrom import LoadAstrometryNetObjectsTask
+from lsst.meas.extensions.astrometryNet import LoadAstrometryNetObjectsTask
 config.processCcd.calibrate.astromRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
 config.processCcd.calibrate.photoRefObjLoader.retarget(LoadAstrometryNetObjectsTask)
 


### PR DESCRIPTION
Update due to DM-2186 change of location of LoadAstrometryNetTask.

Trivial fix.