### PR TITLE
tickets/DM-11410

### DIFF
--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -157,9 +157,12 @@ def plotAstrometryErrorModel(dataset, astromModel, outputPrefix=''):
         color=color['bright'])
 
     # Using title rather than suptitle because I can't get the top padding
-    plt.suptitle("Astrometry Check : %s" % outputPrefix.rstrip('_'),
+    plt.suptitle("Astrometry Check : %s" % outputPrefix,
                  fontsize=30)
-    plotPath = outputPrefix+"check_astrometry.png"
+    if outputPrefix == '':
+        plotPath = "check_astrometry.png"
+    else:
+        plotPath = "%s_%s" % (outputPrefix, "check_astrometry.png")
     plt.savefig(plotPath, format="png")
     plt.close(fig)
 
@@ -391,7 +394,7 @@ def plotPhotometryErrorModel(dataset, photomModel,
                         photomModel, ax=ax[1][1])
     ax[1][1].legend(loc='upper left')
 
-    plt.suptitle("Photometry Check : %s" % outputPrefix.rstrip('_'),
+    plt.suptitle("Photometry Check : %s" % outputPrefix,
                  fontsize=30)
     plotPath = outputPrefix+"check_photometry.png"
     plt.savefig(plotPath, format="png")
@@ -449,7 +452,10 @@ def plotPA1(pa1, outputPrefix=""):
         label.set_visible(False)
 
     plt.tight_layout()  # fix padding
-    plotPath = ''.join((outputPrefix, "PA1.png"))
+    if outputPrefix == '':
+        plotPath = "PA1.png"
+    else:
+        plotPath = "%s_%s" % (outputPrefix, "PA1.png")
     plt.savefig(plotPath, format="png")
     plt.close(fig)
 

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -170,18 +170,18 @@ def repoNameToPrefix(repo):
     Examples
     --------
     >>> repoNameToPrefix('a/b/c')
-    'a_b_c_'
+    'a_b_c'
     >>> repoNameToPrefix('/bar/foo/')
-    'bar_foo_'
+    'bar_foo'
     >>> repoNameToPrefix('CFHT/output')
-    'CFHT_output_'
+    'CFHT_output'
     >>> repoNameToPrefix('./CFHT/output')
-    'CFHT_output_'
+    'CFHT_output'
     >>> repoNameToPrefix('.a/CFHT/output')
-    'a_CFHT_output_'
+    'a_CFHT_output'
     """
 
-    return repo.lstrip('\.').strip(os.sep).replace(os.sep, "_") + "_"
+    return repo.lstrip('\.').strip(os.sep).replace(os.sep, "_")
 
 
 def discoverDataIds(repo, **kwargs):

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -179,9 +179,12 @@ def repoNameToPrefix(repo):
     'CFHT_output'
     >>> repoNameToPrefix('.a/CFHT/output')
     'a_CFHT_output'
+    >>> repoNameToPrefix('bar/foo.json')
+    'bar_foo'
     """
 
-    return repo.lstrip('\.').strip(os.sep).replace(os.sep, "_")
+    baserepo, ext = os.path.splitext(repo)
+    return baserepo.lstrip('.').strip(os.sep).replace(os.sep, "_")
 
 
 def discoverDataIds(repo, **kwargs):

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -217,7 +217,7 @@ def runOneRepo(repo, dataIds=None, metrics=None, outputPrefix='', verbose=False,
 
 def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
                  makePrint=True, makePlot=True, makeJson=True,
-                 filterName=None, outputPrefix=None,
+                 filterName=None, outputPrefix='',
                  verbose=False,
                  **kwargs):
     """Main executable for the case where there is just one filter.
@@ -251,9 +251,6 @@ def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
     verbose : bool, optional
         Output additional information on the analysis steps.
     """
-    if outputPrefix is None:
-        outputPrefix = repoNameToPrefix(repo)
-
     matchedDataset = MatchedMultiVisitDataset(repo, visitDataIds,
                                               verbose=verbose)
     photomModel = PhotometricErrorModel(matchedDataset)

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -131,6 +131,7 @@ def run(repo_or_json, metrics=None, makePrint=True, makePlot=True,
         outputPrefix = kwargs['outputPrefix']
     else:
         outputPrefix = repoNameToPrefix(base_name)
+        kwargs['outputPrefix'] = outputPrefix
 
     if load_json:
         if not os.path.isfile(repo_or_json):

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -129,7 +129,6 @@ def run(repo_or_json, metrics=None,
     # In Python 3 I would have let me mix in a keyword default after *args
     if outputPrefix is None:
         outputPrefix = repoNameToPrefix(base_name)
-        kwargs['outputPrefix'] = outputPrefix
 
     if load_json:
         if not os.path.isfile(repo_or_json):
@@ -144,10 +143,10 @@ def run(repo_or_json, metrics=None,
         if not os.path.isdir(repo_or_json):
             print("Could not find repo %s" % (repo_or_json))
             return
-        kwargs['metrics'] = metrics
 
         repo_path = repo_or_json
-        jobs = runOneRepo(repo_path, **kwargs)
+        jobs = runOneRepo(repo_path, metrics=metrics, outputPrefix=outputPrefix,
+                          **kwargs)
 
     for filterName, job in jobs.items():
         if makePrint:

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -203,7 +203,7 @@ def runOneRepo(repo, dataIds=None, metrics=None, outputPrefix='', verbose=False,
     jobs = {}
     for filterName in allFilters:
         # Do this here so that each outputPrefix will have a different name for each filter.
-        if outputPrefix is None:
+        if outputPrefix is None or outputPrefix == '':
             thisOutputPrefix = "%s" % filterName
         else:
             thisOutputPrefix = "%s_%s_" % (outputPrefix.rstrip('_'), filterName)

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -206,7 +206,7 @@ def runOneRepo(repo, dataIds=None, metrics=None, outputPrefix='', verbose=False,
         if outputPrefix is None or outputPrefix == '':
             thisOutputPrefix = "%s" % filterName
         else:
-            thisOutputPrefix = "%s_%s_" % (outputPrefix.rstrip('_'), filterName)
+            thisOutputPrefix = "%s_%s" % (outputPrefix, filterName)
         theseVisitDataIds = [v for v in dataIds if v['filter'] == filterName]
         job = runOneFilter(repo, theseVisitDataIds, metrics,
                            outputPrefix=thisOutputPrefix,
@@ -297,7 +297,7 @@ def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
                        filterName, specName, verbose=verbose,
                        job=job, linkedBlobs=linkedBlobs)
 
-    job.write_json(outputPrefix.rstrip('_') + '.json')
+    job.write_json(outputPrefix + '.json')
 
     return job
 

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -97,7 +97,8 @@ def get_filter_name_from_job(job):
     return filter_name
 
 
-def run(repo_or_json, metrics=None, makePrint=True, makePlot=True,
+def run(repo_or_json, metrics=None,
+        outputPrefix=None, makePrint=True, makePlot=True,
         level='design', **kwargs):
     """Main entrypoint from ``validateDrp.py``.
 
@@ -126,9 +127,7 @@ def run(repo_or_json, metrics=None, makePrint=True, makePlot=True,
     # I think I have to interrogate the kwargs to maintain compatibility
     # between Python 2 and Python 3
     # In Python 3 I would have let me mix in a keyword default after *args
-    if 'outputPrefix' in kwargs and kwargs['outputPrefix']:
-        outputPrefix = kwargs['outputPrefix']
-    else:
+    if outputPrefix is None:
         outputPrefix = repoNameToPrefix(base_name)
         kwargs['outputPrefix'] = outputPrefix
 

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -117,11 +117,10 @@ def run(repo_or_json, metrics=None, makePrint=True, makePlot=True,
         This can also be the filepath for a JSON file that contains
         the cached output from a previous run.
     """
-    if os.path.splitext(repo_or_json)[-1] == '.json':
-        base_name = repo_or_json[:-5]
+    base_name, ext = os.path.splitext(repo_or_json)
+    if ext == '.json':
         load_json = True
     else:
-        base_name = repo_or_json
         load_json = False
 
     # I think I have to interrogate the kwargs to maintain compatibility

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -301,7 +301,7 @@ def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
     return job
 
 
-def plot_metrics(job, filterName, outputPrefix=None):
+def plot_metrics(job, filterName, outputPrefix=''):
     """Plot AM1, AM2, AM3, PA1 plus related informational plots.
 
     Parameters

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,3 +1,10 @@
 # -*- python -*-
-from lsst.sconsUtils import scripts
+
+import platform
+
+from lsst.sconsUtils import scripts, env
 scripts.BasicSConscript.tests()
+
+# avoid the classic matplotlib "Invalid DISPLAY variable" error
+if platform.system() == "Linux":
+    env["ENV"]["MPLBACKEND"] = "Agg"

--- a/tests/test_load_json.py
+++ b/tests/test_load_json.py
@@ -98,7 +98,7 @@ class ParseJsonJob(unittest.TestCase):
 
         outputPrefix = repoNameToPrefix(self.jsonFile)
         plot_metrics(job, filterName, outputPrefix=outputPrefix)
-        expectedCheckAstrometryFile = outputPrefix+'check_astrometry.png'
+        expectedCheckAstrometryFile = '%s_%s' % (outputPrefix, 'check_astrometry.png')
         assert os.path.exists(expectedCheckAstrometryFile)
 
 

--- a/tests/test_load_json.py
+++ b/tests/test_load_json.py
@@ -31,7 +31,8 @@ import lsst.utils
 
 from lsst.validate.base import load_metrics
 from lsst.validate.drp.validate import (
-    get_filter_name_from_job, load_json_output, print_metrics)
+    get_filter_name_from_job, load_json_output, plot_metrics, print_metrics)
+from lsst.validate.drp.util import repoNameToPrefix
 
 
 class ParseJsonJob(unittest.TestCase):
@@ -81,6 +82,24 @@ class ParseJsonJob(unittest.TestCase):
         filterName = get_filter_name_from_job(job)
         metrics = {meas.metric.name: meas.metric for meas in job.measurements}
         print_metrics(job, filterName, metrics)
+
+    def testPlotMetricsFromJsonJob(self):
+        """Does plotting the metrics run and produce the correct filenames?
+
+        This could be loosely seen as a test of the outputPrefix handling
+        and thus DM-11410, it's a rather incomplete one because the chain
+        of wrapping functions is different.
+        """
+        job = load_json_output(self.jsonFile)
+        filterName = get_filter_name_from_job(job)
+
+        plot_metrics(job, filterName)
+        assert os.path.exists('check_astrometry.png')
+
+        outputPrefix = repoNameToPrefix(self.jsonFile)
+        plot_metrics(job, filterName, outputPrefix=outputPrefix)
+        expectedCheckAstrometryFile = outputPrefix+'check_astrometry.png'
+        assert os.path.exists(expectedCheckAstrometryFile)
 
 
 def setup_module(module):


### PR DESCRIPTION
Quick review.

* Fixed immediate error by adding 'outputPrefix' to `kwargs` if it wasn't already present for suitable passing.
* Added mildly-related test to `tests/test_load_json.py` to make sure that pltos are generated with the expected filename.
* Improved defaults for `outputPrefix=None` for all `run*` routines, but `outputPrefix=''` for `plot_metrics`, which uses it to directly call plotting functions that expect a string for the filename prefix.