### PR TITLE
DM-11585: Add pytest support to packages

### DIFF
--- a/tests/test_amx.py
+++ b/tests/test_amx.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #
 # LSST Data Management System
 # Copyright 2012-2017 LSST Corporation.

--- a/tests/test_coord.py
+++ b/tests/test_coord.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #
 # LSST Data Management System
 # Copyright 2012-2016 LSST Corporation.

--- a/tests/test_load_json.py
+++ b/tests/test_load_json.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #
 # LSST Data Management System
 # Copyright 2012-2016 LSST Corporation.

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #
 # LSST Data Management System
 # Copyright 2012-2016 LSST Corporation.

--- a/tests/test_positionRms.py
+++ b/tests/test_positionRms.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 #
 # LSST Data Management System
 # Copyright 2012-2017 LSST Corporation.


### PR DESCRIPTION
Changes required for the [RFC-215/RFC-229 test file renaming](https://confluence.lsstcorp.org/pages/viewpage.action?pageId=58950873). See the top of that page for the exact changes required.