### PR TITLE
limit output filename prefix length in ParseJsonJob()

### DIFF
--- a/tests/test_load_json.py
+++ b/tests/test_load_json.py
@@ -30,7 +30,6 @@ import lsst.utils
 from lsst.validate.base import load_metrics
 from lsst.validate.drp.validate import (
     get_filter_name_from_job, load_json_output, plot_metrics, print_metrics)
-from lsst.validate.drp.util import repoNameToPrefix
 
 
 class ParseJsonJob(unittest.TestCase):
@@ -103,7 +102,7 @@ class ParseJsonJob(unittest.TestCase):
             os.remove(filename)
 
         # test that outputPrefix is prepended correctly.
-        outputPrefix = repoNameToPrefix(self.jsonFile)
+        outputPrefix = 'foobarbaz'
         outputPrefixFiles = ['%s_%s' % (outputPrefix, f) for f in noOutputPrefixFiles]
         plot_metrics(job, filterName, outputPrefix=outputPrefix)
         for filename in outputPrefixFiles:


### PR DESCRIPTION
Prior to this change, the test could generate extremely long prefix names, leading to a failures on OSX. Eg.:

E           OSError: [Errno 63] File name too long: 'Users_square_jenkins_workspace_release_tarball_osx_10.9_clang-800.0.42.1_miniconda3-4.3.21-10a4fa6_build_stack_miniconda3-4.3.21-10a4fa6_EupsBuildDir_DarwinX86_validate_drp-master-g960648a5d8+11_validate_drp-master-g960648a5d8+11_tests_CfhtQuick_output_r_AM1_D_5_arcmin_17.0_21.5_mag.png'