### PR TITLE
DM-12588: documentation updates

### DIFF
--- a/python/lsst/validate/drp/astromerrmodel.py
+++ b/python/lsst/validate/drp/astromerrmodel.py
@@ -102,7 +102,9 @@ def fitAstromErrModel(snr, dist):
     return params
 
 
-"""Serializable model of astrometry errors across multiple visits.
+def build_astrometric_error_model(matchedMultiVisitDataset, brightSnr=100,
+                 medianRef=100, matchRef=500):
+    """Serializable model of astrometry errors across multiple visits.
 
     .. math::
 
@@ -120,18 +122,16 @@ def fitAstromErrModel(snr, dist):
     matchRef : int, optional
         Should match at least matchRef number of stars (dimensionless).
 
-    Attributes
-    ----------
-    brightSnr : float
-        Threshold SNR for bright sources used in this model.
-    C : float
-        Model scaling factor.
-    theta : float
-        Seeing (milliarcsecond).
-    sigmaSys : float
-        Systematic error floor (milliarcsecond).
-    astromRms : float
-        Astrometric scatter (RMS) for good stars (milliarcsecond).
+    Returns
+    -------
+    blob : `lsst.verify.Blob`
+        Blob with datums:
+
+        - ``brightSnr``: Threshold SNR for bright sources used in this model.
+        - ``C``: Model scaling factor.
+        - ``theta``: Seeing (milliarcsecond).
+        - ``sigmaSys``: Systematic error floor (milliarcsecond).
+        - ``astromRms``: Astrometric scatter (RMS) for good stars (milliarcsecond).
 
     Notes
     -----
@@ -141,9 +141,6 @@ def fitAstromErrModel(snr, dist):
     For SDSS, stars with mag < 19.5 should be completely well measured.
     """
 
-
-def build_astrometric_error_model(matchedMultiVisitDataset, brightSnr=100,
-                 medianRef=100, matchRef=500):
     blob = Blob('AnalyticAstrometryModel')
 
     # FIXME add description field to blobs

--- a/python/lsst/validate/drp/calcsrd/__init__.py
+++ b/python/lsst/validate/drp/calcsrd/__init__.py
@@ -4,7 +4,7 @@ Document.
 
 from .pa1 import measurePA1  # NOQA
 from .pa2 import measurePA2  # NOQA
-from .pf1 import measurePF1  #NOQA
+from .pf1 import measurePF1  # NOQA
 from .amx import measureAMx  # NOQA
 from .afx import measureAFx  # NOQA
 from .adx import measureADx  # NOQA

--- a/python/lsst/validate/drp/calcsrd/adx.py
+++ b/python/lsst/validate/drp/calcsrd/adx.py
@@ -34,7 +34,7 @@ def measureADx(metric, amx, afx_spec):
     ----------
     metric : `lsst.verify.Metric`
         AD1, AD2, or AD3 `~lsst.verify.Metric` instance.
-    amx : :class:`lsst.verify.Measurement`
+    amx : `lsst.verify.Measurement`
         And AMx measurement, providing the median astrometric scatter in
         the annulus.
     afx_spec : `lsst.verify.Spec`
@@ -43,7 +43,8 @@ def measureADx(metric, amx, afx_spec):
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of ADx (x=1,2,3) and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of ADx (x=1,2,3) and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/calcsrd/adx.py
+++ b/python/lsst/validate/drp/calcsrd/adx.py
@@ -26,31 +26,24 @@ import astropy.units as u
 from lsst.verify import Measurement
 
 
-"""Measurement of AFx (x=1,2,3): The maximum fraction of astrometric
+def measureADx(metric, amx, afx_spec):
+    """Measurement of AFx (x=1,2,3): The maximum fraction of astrometric
     distances which deviate by more than ADx milliarcsec (see AMx) (%).
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        AD1, AD2, or AD3 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    amx : :class:`lsst.validate.drp.calcsrd.AMxMeasurement`
+    metric : `lsst.verify.Metric`
+        AD1, AD2, or AD3 `~lsst.verify.Metric` instance.
+    amx : :class:`lsst.verify.Measurement`
         And AMx measurement, providing the median astrometric scatter in
         the annulus.
-    filter_name : str
-        filter_name (filter name) used in this measurement (e.g., `'r'`).
-    spec_name : str
-        Name of a specification level to measure against (e.g., design,
+    afx_spec : `lsst.verify.Spec`
+        Specification containing the value of the level to measure against (e.g., design,
         minimum, stretch).
-    verbose : bool, optional
-        Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., `matchedDataset).
+
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of ADx (x=1,2,3) and associated metadata.
 
     Notes
     -----
@@ -94,8 +87,6 @@ from lsst.verify import Measurement
     and to astrometric measurements performed in the r and i bands.
     """
 
-
-def measureADx(metric, amx, afx_spec):
     if not np.isnan(amx.quantity):
         # No more than AFx of values will deviate by more than the
         # AMx (50th) + AFx percentiles

--- a/python/lsst/validate/drp/calcsrd/afx.py
+++ b/python/lsst/validate/drp/calcsrd/afx.py
@@ -34,18 +34,19 @@ def measureAFx(metric, amx, adx, adx_spec):
     ----------
     metric : `lsst.verify.Metric`
         AF1, AF2 or AF3 `~lsst.verify.Metric` instance.
-    amx : :class:`lsst.verify.Measurement`
+    amx : `lsst.verify.Measurement`
         An AMx measurement, providing the median astrometric scatter in
         the annulus.
-    adx : :class:`lsst.verify.Measurement`
+    adx : `lsst.verify.Measurement`
         An ADx measurement
-    adx_spec : :class:`lsst.verify.Spec`
+    adx_spec : `lsst.verify.Spec`
         An instance of a `lsst.verify.Spec` containing the threshold against
         which to measure.
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of AFx (x=1,2,3) and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of AFx (x=1,2,3) and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/calcsrd/afx.py
+++ b/python/lsst/validate/drp/calcsrd/afx.py
@@ -26,31 +26,26 @@ import astropy.units as u
 from lsst.verify import Measurement
 
 
-"""Measurement of AFx (x=1,2,3): The maximum fraction of astrometric
+def measureAFx(metric, amx, adx, adx_spec):
+    """Measurement of AFx (x=1,2,3): The maximum fraction of astrometric
     distances which deviate by more than ADx milliarcsec (see AMx) (%).
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        AF1, AF2 or AF3 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    amx : :class:`lsst.validate.drp.calcsrd.AMxMeasurement`
-        And AMx measurement, providing the median astrometric scatter in
+    metric : `lsst.verify.Metric`
+        AF1, AF2 or AF3 `~lsst.verify.Metric` instance.
+    amx : :class:`lsst.verify.Measurement`
+        An AMx measurement, providing the median astrometric scatter in
         the annulus.
-    bandpass : str
-        Bandpass (filter name) used in this measurement (e.g., `'r'`).
-    spec_name : str
-        Name of a specification level to measure against (e.g., design,
-        minimum, stretch).
-    verbose : bool, optional
-        Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., `matchedDataset).
+    adx : :class:`lsst.verify.Measurement`
+        An ADx measurement
+    adx_spec : :class:`lsst.verify.Spec`
+        An instance of a `lsst.verify.Spec` containing the threshold against
+        which to measure.
+
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of AFx (x=1,2,3) and associated metadata.
 
     Notes
     -----
@@ -94,12 +89,11 @@ from lsst.verify import Measurement
     and to astrometric measurements performed in the r and i bands.
     """
 
-
-def measureAFx(metric, amx, adx, adx_spec):
     datums = {}
     datums['ADx'] = adx.datum
     if not np.isnan(amx.quantity):
-        quantity = 100.*np.mean(amx.extras['rmsDistMas'].quantity > amx.quantity + adx_spec.threshold)*u.Unit('percent')
+        quantity = 100.*np.mean(amx.extras['rmsDistMas'].quantity > amx.quantity +
+                                adx_spec.threshold)*u.Unit('percent')
     else:
         quantity = np.nan*u.Unit('percent')
     datums.update(amx.extras)

--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -53,7 +53,8 @@ def measureAMx(metric, matchedDataset, D, width=2., magRange=None, verbose=False
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of AMx (x=1,2,3) and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of AMx (x=1,2,3) and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -26,21 +26,23 @@ import astropy.units as u
 
 from lsst.verify import Measurement, Datum
 
-from ..util import (averageRaDecFromCat, averageRaFromCat, averageDecFromCat,
+from ..util import (averageRaFromCat, averageDecFromCat,
                     sphDist)
 
 
-"""Measurement of AMx (x=1,2,3): The maximum rms of the astrometric
+def measureAMx(metric, matchedDataset, D, width=2., magRange=None, verbose=False):
+    """Measurement of AMx (x=1,2,3): The maximum rms of the astrometric
     distance distribution for stellar pairs with separations of D arcmin
     (repeatability).
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        An AM1, AM2 or AM3 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    filter_name : `str`
-        filter_name (filter name) used in this measurement (e.g., ``'r'``).
+    metric : `lsst.verify.Metric`
+        An AM1, AM2 or AM3 `~lsst.verify.Metric` instance.
+    matchedDataset : lsst.verify.Blob
+        Contains the spacially matched dataset for the measurement
+    D : `astropy.units.Quantity`
+        Radial distance of the annulus in arcmin
     width : `float` or `astropy.units.Quantity`, optional
         Width around fiducial distance to include. [arcmin]
     magRange : 2-element `list`, `tuple`, or `numpy.ndarray`, optional
@@ -48,20 +50,10 @@ from ..util import (averageRaDecFromCat, averageRaFromCat, averageDecFromCat,
         Default: ``[17.5, 21.5]`` mag.
     verbose : `bool`, optional
         Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., ``matchedDataset``).
 
-    Attributes
-    ----------
-    rmsDistMas : ndarray
-        RMS of distance repeatability between stellar pairs.
-    blob : AMxBlob
-        Blob with by-products from this measurement.
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of AMx (x=1,2,3) and associated metadata.
 
     Notes
     -----
@@ -105,8 +97,6 @@ from ..util import (averageRaDecFromCat, averageRaFromCat, averageDecFromCat,
     and to astrometric measurements performed in the r and i bands.
     """
 
-
-def measureAMx(metric, matchedDataset, D, width=2., magRange=None, verbose=False):
     matches = matchedDataset.safeMatches
 
     datums = {}
@@ -127,7 +117,7 @@ def measureAMx(metric, matchedDataset, D, width=2., magRange=None, verbose=False
 
     annulus = D + (width/2)*np.array([-1, +1])
     datums['annulus'] = Datum(quantity=annulus, label='annulus radii',
-                             description='Inner and outer radii of selection annulus.')
+                              description='Inner and outer radii of selection annulus.')
 
     # Register measurement extras
     rmsDistances = calcRmsDistances(
@@ -147,6 +137,7 @@ def measureAMx(metric, matchedDataset, D, width=2., magRange=None, verbose=False
         quantity = np.median(rmsDistances.to(u.marcsec))
 
     return Measurement(metric.name, quantity, extras=datums)
+
 
 def calcRmsDistances(groupView, annulus, magRange, verbose=False):
     """Calculate the RMS distance of a set of matched objects over visits.

--- a/python/lsst/validate/drp/calcsrd/pa1.py
+++ b/python/lsst/validate/drp/calcsrd/pa1.py
@@ -48,7 +48,8 @@ def measurePA1(metric, matchedDataset, filterName, numRandomShuffles=50):
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of PA1 and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of PA1 and associated metadata.
 
     See also
     --------

--- a/python/lsst/validate/drp/calcsrd/pa1.py
+++ b/python/lsst/validate/drp/calcsrd/pa1.py
@@ -31,39 +31,24 @@ import lsst.pipe.base as pipeBase
 from lsst.verify import Measurement, Datum
 
 
-"""Measurement of the PA1 metric: photometric repeatability of
+def measurePA1(metric, matchedDataset, filterName, numRandomShuffles=50):
+    """Measurement of the PA1 metric: photometric repeatability of
     measurements across a set of observations.
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        A PA1 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    filter_name : str
-        filter_name (filter name) used in this measurement (e.g., `'r'`)
+    metric : `lsst.verify.Metric`
+        A PA1 `~lsst.verify.Metric` instance.
+    matchedDataset : `lsst.verify.Blob`
+        This contains the spacially matched catalog to do the measurement.
+    filterName : str
+        filter name used in this measurement (e.g., `'r'`)
     numRandomShuffles : int
         Number of times to draw random pairs from the different observations.
-    verbose : bool, optional
-        Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., `matchedDataset).
 
-    Attributes
-    ----------
-    rms : ndarray
-        Photometric repeatability RMS of stellar pairs for each random
-        sampling.
-    iqr : ndarray
-       Photometric repeatability IQR of stellar pairs for each random sample.
-    magDiff : ndarray
-        Magnitude differences of stars between visits, for each random sample.
-    magMean : ndarray
-        Mean magnitude of stars seen across visits, for each random sample.
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of PA1 and associated metadata.
 
     See also
     --------
@@ -72,14 +57,12 @@ from lsst.verify import Measurement, Datum
         the PA1 measurement.
     """
 
-
-def measurePA1(metric, matchedDataset, filterName, numRandomShuffles=50):
     matches = matchedDataset.safeMatches
     magKey = matchedDataset.magKey
     results = calcPa1(matches, magKey, numRandomShuffles=numRandomShuffles)
     datums = {}
     datums['filter_name'] = Datum(filterName, label='filter',
-                                   description='Name of filter for this measurement')
+                                  description='Name of filter for this measurement')
     datums['rms'] = Datum(results['rms'], label='RMS',
                           description='Photometric repeatability RMS of stellar pairs for '
                           'each random sampling')
@@ -104,12 +87,14 @@ def calcPa1(matches, magKey, numRandomShuffles=50):
     matches : `lsst.afw.table.GroupView`
         `~lsst.afw.table.GroupView` of stars matched between visits,
         from MultiMatch, provided by
-        `lsst.validate.drp.matchreduce.MatchedMultiVisitDataset`.
+        `lsst.validate.drp.matchreduce.build_matched_dataset`.
     magKey : `lsst.afw.table` schema key
         Magnitude column key in the ``groupView``.
         E.g., ``magKey = allMatches.schema.find("base_PsfFlux_mag").key``
         where ``allMatches`` is the result of
         `lsst.afw.table.MultiMatch.finish()`.
+    numRandomShuffles : int
+        Number of times to draw random pairs from the different observations.
 
     Returns
     -------
@@ -164,8 +149,8 @@ def calcPa1(matches, magKey, numRandomShuffles=50):
 
     Examples
     --------
-    Normally ``calcPa1`` is called by `PA1Measurement`, using data from
-    `lsst.validate.drp.matchreduce.MultiVisitMatchedDataset`. Here's an
+    Normally ``calcPa1`` is called by `measurePA1`, using data from
+    `lsst.validate.drp.matchreduce.build_matched_dataset`. Here's an
     example of how to call ``calcPa1`` directly given a Butler output
     repository:
 
@@ -212,7 +197,7 @@ def calcPa1Sample(matches, magKey):
     matches : `lsst.afw.table.GroupView`
         `~lsst.afw.table.GroupView` of stars matched between visits,
         from MultiMatch, provided by
-        `lsst.validate.drp.matchreduce.MatchedMultiVisitDataset`.
+        `lsst.validate.drp.matchreduce.build_matched_dataset`.
     magKey : `lsst.afw.table` schema key
         Magnitude column key in the ``groupView``.
         E.g., ``magKey = allMatches.schema.find("base_PsfFlux_mag").key``
@@ -240,8 +225,8 @@ def calcPa1Sample(matches, magKey):
 
     Examples
     --------
-    Normally ``calcPa1`` is called by `PA1Measurement`, using data from
-    `lsst.validate.drp.matchreduce.MultiVisitMatchedDataset`. Here's an
+    Normally ``calcPa1`` is called by `measurePA1`, using data from
+    `lsst.validate.drp.matchreduce.build_matched_dataset`. Here's an
     example of how to call ``calcPa1Sample`` directly given a Butler output
     repository:
     """

--- a/python/lsst/validate/drp/calcsrd/pa2.py
+++ b/python/lsst/validate/drp/calcsrd/pa2.py
@@ -26,30 +26,22 @@ import astropy.units as u
 from lsst.verify import Measurement, Datum
 
 
-"""Measurement of PA2: millimag from median RMS (see PA1) of which
+def measurePA2(metric, pa1, pf1_thresh): 
+    """Measurement of PA2: millimag from median RMS (see PA1) of which
     PF1 of the samples can be found.
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        A PA2 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    pa1 : PA1Measurement
+    metric : `lsst.verify.Metric`
+        A PA2 `~lsst.verify.Metric` instance.
+    pa1 : `lsst.verify.Measurement`
         A PA1 measurement instance.
-    filter_name : str
-        filter_name (filter name) used in this measurement (e.g., `'r'`).
-    spec_name : str
-        Name of a specification level to measure against (e.g., design,
-        minimum, stretch).
-    verbose : bool, optional
-        Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., `matchedDataset).
+    pf1_thresh : `astropy.units.Quantity`
+        Quantity specifying the threshold at which to calculate PA2
+
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of PA2 and associated metadata.
 
     Notes
     -----
@@ -60,14 +52,12 @@ from lsst.verify import Measurement, Datum
     LPM-17 as of 2011-07-06, available at http://ls.st/LPM-17.
     """
 
+    datums = {}
+    datums['pf1_thresh'] = Datum(quantity=pf1_thresh, description="Threshold from the PF1 specification")
 
-def measurePA2(metric, pa1, pf1_thresh): 
-        datums = {}
-        datums['pf1_thresh'] = Datum(quantity=pf1_thresh, description="Threshold from the PF1 specification")
+    # Use first random sample from original PA1 measurement
+    magDiffs = pa1.extras['magDiff'].quantity[0, :]
 
-        # Use first random sample from original PA1 measurement
-        magDiffs = pa1.extras['magDiff'].quantity[0, :]
-
-        pf1Percentile = 100.*u.percent - pf1_thresh
-        return Measurement(metric, np.percentile(np.abs(magDiffs), pf1Percentile) * magDiffs.unit,
-                           extras=datums)
+    pf1Percentile = 100.*u.percent - pf1_thresh
+    return Measurement(metric, np.percentile(np.abs(magDiffs), pf1Percentile) * magDiffs.unit,
+                       extras=datums)

--- a/python/lsst/validate/drp/calcsrd/pa2.py
+++ b/python/lsst/validate/drp/calcsrd/pa2.py
@@ -41,7 +41,8 @@ def measurePA2(metric, pa1, pf1_thresh):
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of PA2 and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of PA2 and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/calcsrd/pf1.py
+++ b/python/lsst/validate/drp/calcsrd/pf1.py
@@ -26,30 +26,22 @@ import astropy.units as u
 from lsst.verify import Measurement, Datum
 
 
-"""Measurement of PF1: fraction of samples between median RMS (PA1) and
+def measurePF1(metric, pa1, pa2_spec):
+    """Measurement of PF1: fraction of samples between median RMS (PA1) and
     PA2 specification.
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        A PF1 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
-    pa1 : PA1Measurement
+    metric : `lsst.verify.Metric`
+        A PF1 `~lsst.verify.Metric` instance.
+    pa1 : `lsst.verify.Measurement`
         A PA1 measurement instance.
-    filter_name : str
-        filter_name (filter name) used in this measurement (e.g., `'r'`).
-    spec_name : str
-        Name of a specification level to measure against (e.g., design,
-        minimum, stretch).
-    verbose : bool, optional
-        Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., `matchedDataset).
+    pa2_spec : `lsst.verify.Spec`
+        An `lsst.verify.Spec` that holds the threshold at which to measure PF1
+
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of PF1 and associated metadata.
 
     Notes
     -----
@@ -60,8 +52,6 @@ from lsst.verify import Measurement, Datum
     LPM-17 as of 2011-07-06, available at http://ls.st/LPM-17.
     """
 
-
-def measurePF1(metric, pa1, pa2_spec):
     datums = {}
     datums['pa2_spec'] = Datum(quantity=pa2_spec.threshold, description="Threshold applied to PA2")
     # Use first random sample from original PA1 measurement

--- a/python/lsst/validate/drp/calcsrd/pf1.py
+++ b/python/lsst/validate/drp/calcsrd/pf1.py
@@ -41,7 +41,8 @@ def measurePF1(metric, pa1, pa2_spec):
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of PF1 and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of PF1 and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/calcsrd/tex.py
+++ b/python/lsst/validate/drp/calcsrd/tex.py
@@ -32,31 +32,26 @@ from ..util import (averageRaFromCat, averageDecFromCat,
                     medianEllipticity2ResidualsFromCat)
 
 
-"""Measurement of TEx (x=1,2): Correlation of PSF residual ellipticity
+def measureTEx(metric, matchedDataset, D, bin_range_operator, verbose=False):
+    """Measurement of TEx (x=1,2): Correlation of PSF residual ellipticity
     on scales of D=(1, 5) arcmin.
 
     Parameters
     ----------
-    metric : `lsst.validate.base.Metric`
-        An TE1 or TE2 `~lsst.validate.base.Metric` instance.
-    matchedDataset : lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
+    metric : `lsst.verify.Metric`
+        An TE1 or TE2 `~lsst.verify.Metric` instance.
+    matchedDataset : lsst.verify.Blob
         The matched catalogs to analyze.
-    filter_name : `str`
-        filter_name (filter name) used in this measurement (e.g., ``'r'``).
+    D : `astropy.units.Quantity`
+        Radial size of annulus in arcmin
+    bin_range_operator : str
+        String representation to use in comparisons
     verbose : `bool`, optional
         Output additional information on the analysis steps.
-    job : :class:`lsst.validate.drp.base.Job`, optional
-        If provided, the measurement will register itself with the Job
-        object.
-    linkedBlobs : dict, optional
-        A `dict` of additional blobs (subclasses of BlobBase) that
-        can provide additional context to the measurement, though aren't
-        direct dependencies of the computation (e.g., ``matchedDataset``).
 
-    Attributes
-    ----------
-    blob : TExBlob
-        Blob with by-products from this measurement.
+    Returns
+    -------
+    An `lsst.verify.Measurement` containing the measured value of TEx (x=1,2) and associated metadata.
 
     Notes
     -----
@@ -97,8 +92,6 @@ from ..util import (averageRaFromCat, averageDecFromCat,
     Table 27: These residual PSF ellipticity correlations apply to the r and i bands.
     """
 
-
-def measureTEx(metric, matchedDataset, D, bin_range_operator, verbose=False):
     matches = matchedDataset.safeMatches
 
     datums = {}
@@ -110,8 +103,8 @@ def measureTEx(metric, matchedDataset, D, bin_range_operator, verbose=False):
     datums['xip_err'] = Datum(quantity=xip_err, description="Correlation strength uncertainty")
     datums['bin_range_operator'] = Datum(quantity=bin_range_operator, description="Bin range operator string")
 
-    corr, corr_err = select_bin_from_corr(radius, xip, xip_err, radius=D,
-                                          operator=ThresholdSpecification.convert_operator_str(bin_range_operator))
+    operator = ThresholdSpecification.convert_operator_str(bin_range_operator)
+    corr, corr_err = select_bin_from_corr(radius, xip, xip_err, radius=D, operator=operator)
     quantity = np.abs(corr) * u.Unit('')
     return Measurement(metric, quantity, extras=datums)
 
@@ -123,7 +116,7 @@ def correlation_function_ellipticity_from_matches(matches, **kwargs):
 
     Parameters
     ----------
-    matches : `lsst.validate.drp.matchreduce.MatchedMultiVisitDataset`
+    matches : `lsst.verify.Blob`
         - The matched catalogs to analyze.
 
     Returns
@@ -240,6 +233,8 @@ def plot_correlation_function_ellipticity(r, xip, xip_err,
         Two-point correlation
     xip_err : numpy.array
         Uncertainty on two-point correlation
+    plotfile : Str
+        Name of file to save the figure in.
 
     Effects
     -------

--- a/python/lsst/validate/drp/calcsrd/tex.py
+++ b/python/lsst/validate/drp/calcsrd/tex.py
@@ -51,7 +51,8 @@ def measureTEx(metric, matchedDataset, D, bin_range_operator, verbose=False):
 
     Returns
     -------
-    An `lsst.verify.Measurement` containing the measured value of TEx (x=1,2) and associated metadata.
+    measurement : `lsst.verify.Measurement`
+        Measurement of TEx (x=1,2) and associated metadata.
 
     Notes
     -----

--- a/python/lsst/validate/drp/matchreduce.py
+++ b/python/lsst/validate/drp/matchreduce.py
@@ -42,10 +42,12 @@ from .util import (getCcdKeyName, positionRmsFromCat, ellipticity_from_cat)
 __all__ = ['build_matched_dataset']
 
 
-"""Container for matched star catalogs from multple visits, with filtering,
+def build_matched_dataset(repo, dataIds, matchRadius=None, safeSnr=50.,
+             useJointCal=False):
+    """Construct a container for matched star catalogs from multple visits, with filtering,
     summary statistics, and modelling.
 
-    `MatchedMultiVisitDataset` instances are serializable to JSON.
+    `lsst.verify.Blob` instances are serializable to JSON.
 
     Parameters
     ----------
@@ -59,10 +61,10 @@ __all__ = ['build_matched_dataset']
         Radius for matching. Default is 1 arcsecond.
     safeSnr : `float`, optional
         Minimum median SNR for a match to be considered "safe".
-    verbose : `bool`, optional
-        Output additional information on the analysis steps.
+    useJointCal : `bool`, optional
+        Indicates whether jointcal calibrations were used
 
-    Attributes
+    Attributes of returned Blob
     ----------
     filterName : `str`
         Name of filter used for all observations.
@@ -78,6 +80,8 @@ __all__ = ['build_matched_dataset']
         (dimensionless).
     dist : `astropy.units.Quantity`
         RMS of sky coordinates of stars over multiple visits (milliarcseconds).
+
+        *Not serialized.*
     goodMatches
         all good matches, as an afw.table.GroupView;
         good matches contain only objects whose detections all have
@@ -101,10 +105,6 @@ __all__ = ['build_matched_dataset']
 
         *Not serialized.*
     """
-
-
-def build_matched_dataset(repo, dataIds, matchRadius=None, safeSnr=50.,
-             useJointCal=False):
     blob = Blob('MatchedMultiVisitDataset')
 
     if not matchRadius:
@@ -147,9 +147,9 @@ def _loadAndMatchCatalogs(repo, dataIds, matchRadius,
 
     Returns
     -------
-    afw.table.SourceCatalog
+    catalog_list : afw.table.SourceCatalog
         List of all of the catalogs
-    afw.table.GroupView
+    matched_catalog : afw.table.GroupView
         An object of matched catalog.
     """
     # Following

--- a/python/lsst/validate/drp/photerrmodel.py
+++ b/python/lsst/validate/drp/photerrmodel.py
@@ -146,7 +146,9 @@ def fitPhotErrModel(mag, mag_err):
     return params
 
 
-"""Serializable analytic photometry error model for a single visit.
+def build_photometric_error_model(matchedMultiVisitDataset, brightSnr=100, medianRef=100,
+                                  matchRef=500):
+    """Returns a serializable analytic photometry error model for a single visit.
 
     This model is originally presented in http://arxiv.org/abs/0805.2366v4
     (Eq 4, 5):
@@ -169,18 +171,16 @@ def fitPhotErrModel(mag, mag_err):
     matchRef : `int` or `astropy.unit.Quantity, optional
         Should match at least matchRef stars.
 
-    Attributes
+    Returns
     ----------
-    brightSnr : `astropy.unit.Quantity`
-        Threshold in SNR for bright sources used in this  model.
-    sigmaSys : `astropy.unit.Quantity`
-        Systematic error floor.
-    gamma : `astropy.unit.Quantity`
-        Proxy for sky brightness and read noise.
-    m5 : `astropy.unit.Quantity`
-        5-sigma photometric depth (magnitudes).
-    photRms : `astropy.unit.Quantity`
-        RMS photometric scatter for 'good' stars (millimagnitudes).
+    blob : `lsst.verify.Blob`
+        Blob with datums:
+
+        - ``brightSnr``: Threshold in SNR for bright sources used in this  model.
+        - ``sigmaSys``: Systematic error floor.
+        - ``gamma``: Proxy for sky brightness and read noise.
+        - ``m5``: 5-sigma photometric depth (magnitudes).
+        - ``photRms``: RMS photometric scatter for 'good' stars (millimagnitudes).
 
     Notes
     -----
@@ -188,10 +188,6 @@ def fitPhotErrModel(mag, mag_err):
     For SDSS, stars with mag < 19.5 should be completely well measured.
     This limit is a band-dependent statement most appropriate to r.
     """
-
-
-def build_photometric_error_model(matchedMultiVisitDataset, brightSnr=100, medianRef=100,
-                                  matchRef=500):
     blob = Blob('PhotometricErrorModel')
 
 

--- a/python/lsst/validate/drp/plot.py
+++ b/python/lsst/validate/drp/plot.py
@@ -100,10 +100,10 @@ def plotAstrometryErrorModel(dataset, astromModel, outputPrefix=''):
 
     Parameters
     ----------
-    dataset : `MatchedMultiVisitDataset`
+    dataset : `lsst.verify.Blob`
         Blob with the multi-visit photometry model.
-    photomModel : `AnalyticPhotometryModel`
-        An analyticPhotometry model object.
+    photomModel : `lsst.verify.Blob`
+        A `Blob` containing the analytic photometry model.
     outputPrefix : str, optional
         Prefix to use for filename of plot file.  Will also be used in plot
         titles. E.g., ``outputPrefix='Cfht_output_r_'`` will result in a file
@@ -196,8 +196,8 @@ def plotAstromErrModelFit(snr, dist, model,
         S/N of photometric measurements
     dist : list or numpy.array
         Separation from reference [mas]
-    model : `AnalyticAstrometryModel`
-        An `AnalyticAstrometryModel` instance.
+    model : `lsst.verify.Blob`
+        A `Blob` holding the analytic astrometric model.
     """
     if ax is None:
         ax = plt.figure()
@@ -238,8 +238,8 @@ def plotPhotErrModelFit(mag, mmag_err, photomModel, color='red', ax=None,
         Magnitude
     mmag_err : list or numpy.array
         Magnitude uncertainty or variation in *mmag*.
-    photomModel : `AnalyticPhotometryModel`
-        Fit parameters to display.
+    photomModel : `lsst.verify.Blob`
+        A `Blob` holding the parameters to display.
     ax : matplotlib.Axis, optional
         The Axis object to plot to.
     verbose : bool, optional
@@ -279,10 +279,10 @@ def plotPhotometryErrorModel(dataset, photomModel,
 
     Parameters
     ----------
-    dataset : `MatchedMultiVisitDataset`
-        Blob with the multi-visit photometry model.
-    photomModel : `AnalyticPhotometryModel`
-        An analyticPhotometry model object.
+    dataset : `lsst.verify.Blob`
+        A `Blob` with the multi-visit photometry model.
+    photomModel : `lsst.verify.Blob`
+        A `Blob` hlding the analytic photometry model parameters.
     filterName : str, optional
         Name of the observed filter to use on axis labels.
     outputPrefix : str, optional
@@ -428,8 +428,8 @@ def plotPA1(pa1, outputPrefix=""):
 
     Parameters
     ----------
-    pa1 : `PA1Measurement`
-        A PA1 object.
+    pa1 : `lsst.verify.Measurement`
+        A `Measurement` of the PA1 `Metric`.
     outputPrefix : `str`, optional
         Prefix to use for filename of plot file.  Will also be used in plot
         titles. E.g., outputPrefix='Cfht_output_r_' will result in a file
@@ -491,8 +491,11 @@ def plotAMx(job, amx, afx, filterName, amxSpecName='design', outputPrefix=""):
 
     Parameters
     ----------
-    amx : `AMxMeasurement`
-    afx : `AFxMeasurement`
+    job : `lsst.verify.Job`
+        `~lsst.verify.Job` providing access to metrics, specs and measurements
+    amx : `lsst.verify.Measurement`
+    afx : `lsst.verify.Measurement`
+    filterName : `str`
     amxSpecName : `str`, optional
         Name of the AMx specification to reference in the plot.
         Default: ``'design'``.
@@ -588,8 +591,10 @@ def plotTEx(job, tex, filterName, texSpecName='design', outputPrefix=''):
 
     Parameters
     ----------
-    tex : Measurement object
-        The ellipticity residual correlation Measurement object
+    job : `lsst.verify.Job`
+        `Job` providing access to metrics, specs, and measurements
+    tex : `lsst.verify.Measurement
+        The ellipticity residual correlation `Measurement` object
     filterName : str
         Name of the filter of the images
     texSpecName : str

--- a/python/lsst/validate/drp/report_performance.py
+++ b/python/lsst/validate/drp/report_performance.py
@@ -32,17 +32,14 @@ def run(validation_drp_report_filenames, output_file,
     """
     Parameters
     ---
-    validation_drp_report_filenames : [] or str, filepaths for JSON files.
-    output_file : str, filepath of output RST file.
-    srd_level : str, SRD level to quote.  One of ['design', 'minimum', 'stretch']
-    release_specs_file : str [optional], filepath of metrics YAML file
-      While the JSON file itself will store the metrics the was calculated with
-        one may wish to compare against an external set of specifications.
-      E.g., ${VALIDATE_DRP_DIR}/etc/release_specs.yaml
-        contains the target levels for each fiscal year through to and including
-        operational readiness review (ORR).  This file is essentially the same
-        as ${VALIDATE_DRP_DIR}/etc/metrics.yaml, but defines levels in terms
-        of fiscal year and ORR instead of design/minimum/stretch.
+    validation_drp_report_filenames : list or str
+        filepaths for JSON files.
+    output_file : str
+        filepath of output RST file.
+    srd_level : str
+        SRD level to quote.  One of ['design', 'minimum', 'stretch']
+    release_specs_package : str, optional
+        Name of package to use in constructing the release level specs.
     release_level : str, A specification level in the 'release_specs_file'
        E.g., 'FY17' or 'ORR'
 
@@ -74,7 +71,7 @@ def ingest_data(filenames):
 
     Returns
     -------
-    list of lsst.validate.base.Job
+    job_list : list of lsst.validate.base.Job
         Each element is the Job representation of the JSON file.
     """
     jobs = {}
@@ -104,7 +101,7 @@ def objects_to_table(input_objects, level='design'):
 
     Returns
     -------
-    astropy.table.Table
+    report : astropy.table.Table
         Table with columns needed for final report.
     """
     rows = []
@@ -112,9 +109,9 @@ def objects_to_table(input_objects, level='design'):
         specs, metrics = get_specs_metrics(job)
         for key, m in job.measurements.items():
             parts = key.metric.split("_")
-            metric = parts[0] # For compound metrics
+            metric = parts[0]  # For compound metrics
             if len(parts) > 1:
-                if not level in ".".join(parts):
+                if level not in ".".join(parts):
                     continue
             spec_set = specs[metric]
             spec = None
@@ -220,9 +217,9 @@ def write_report(data, filename='test.rst', format='ascii.rst'):
     Parameters
     ----------
     data : astropy.table.Table
-    filename : str [optional]
+    filename : str, optional
         Filepath of output RST file.
-    format : str [optional]
+    format : str, optional
         astropy.table format for output table.
 
     Creates

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -223,7 +223,7 @@ def averageRaFromCat(cat):
     """Compute the average right ascension from a catalog of measurements.
 
     This function is used as an aggregate function to extract just RA
-    from an lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
+    from lsst.validate.drp.matchreduce.build_matched_dataset
 
     The actual computation involves both RA and Dec.
 
@@ -248,7 +248,7 @@ def averageDecFromCat(cat):
     """Compute the average declination from a catalog of measurements.
 
     This function is used as an aggregate function to extract just declination
-    from an lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
+    from lsst.validate.drp.matchreduce.build_matched_dataset
 
     The actual computation involves both RA and Dec.
 
@@ -273,7 +273,7 @@ def medianEllipticityResidualsFromCat(cat):
     """Compute the median ellipticty residuals from a catalog of measurements.
 
     This function is used as an aggregate function to extract just declination
-    from an lsst.validate.drp.matchreduce.MatchedMultiVisitDataset
+    from lsst.validate.drp.matchreduce.build_matched_dataset
 
     The intent is to use this for a set of measurements of the same source
     but that's neither enforced nor required.


### PR DESCRIPTION
Switch to referring to `lsst.verify` objects instead of `lsst.validate.base` objects.