### PR TITLE
Use WORKSPACE instead of PRODUCT_DIR for run list.

### DIFF
--- a/examples/runExample.sh
+++ b/examples/runExample.sh
@@ -78,7 +78,7 @@ NUMPROC=${NUMPROC:-$((sys_proc < max_proc ? sys_proc : max_proc))}
 
 # Extract desired dataIds runs from YAML config file
 YAMLCONFIG="${PRODUCT_DIR}"/examples/${CAMERA}.yaml
-RUNLIST="${PRODUCT_DIR}"/examples/${CAMERA}.list
+RUNLIST="${WORKSPACE}"/"${CAMERA}".list
 makeRunList.py "${YAMLCONFIG}" > "${RUNLIST}"
 
 ${PROCESSCCD} "${INPUT}" --output "${OUTPUT}" \


### PR DESCRIPTION
Example script wrote to $VALIDATE_DRP_DIR for its run list.

This was unncecessary and created an error if the user didn't have
permission to write to the directory.