### PR TITLE
Add --skipTEx argument to validateDrp to control from command line.

### DIFF
--- a/bin.src/validateDrp.py
+++ b/bin.src/validateDrp.py
@@ -65,6 +65,8 @@ if __name__ == "__main__":
                         help='Skip making plots of performance.')
     parser.add_argument('--level', type=str, default='design',
                         help='Level of SRD requirement to meet: "minimum", "design", "stretch"')
+    parser.add_argument('--skipTEx', default=False, action='store_true',
+                        help='Skip TEx calculations.')
 
     args = parser.parse_args()
 
@@ -95,5 +97,6 @@ if __name__ == "__main__":
     kwargs['verbose'] = args.verbose
     kwargs['makePlot'] = args.makePlot
     kwargs['level'] = args.level
+    kwargs['skipTEx'] = args.skipTEx
 
     validate.run(args.repo, **kwargs)


### PR DESCRIPTION
Trivial change that exposes the --skipTEx option to the command line.