### PR TITLE
DM-11922: Add hack to convert raft, sensor x,y to one int.  Allows validate_drp to run on obs_lsstSim

### DIFF
--- a/python/lsst/validate/drp/matchreduce.py
+++ b/python/lsst/validate/drp/matchreduce.py
@@ -37,7 +37,8 @@ from lsst.afw.table import (SourceCatalog, SchemaMapper, Field,
 from lsst.afw.fits import FitsError
 from lsst.validate.base import BlobBase
 
-from .util import (getCcdKeyName, positionRmsFromCat, ellipticity_from_cat)
+from .util import (getCcdKeyName, raftSensorToInt, positionRmsFromCat,
+                   ellipticity_from_cat)
 
 
 __all__ = ['MatchedMultiVisitDataset']
@@ -204,6 +205,12 @@ class MatchedMultiVisitDataset(BlobBase):
         #    dataRefs = [dafPersist.ButlerDataRef(butler, vId) for vId in dataIds]
 
         ccdKeyName = getCcdKeyName(dataIds[0])
+
+        # Hack to support raft and sensor 0,1 IDs as ints for multimatch
+        if ccdKeyName == 'sensor':
+            ccdKeyName = 'raft_sensor_int'
+            for vId in dataIds:
+                vId[ccdKeyName] = raftSensorToInt(vId)
 
         schema = butler.get(dataset + "_schema").schema
         mapper = SchemaMapper(schema)

--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -342,13 +342,29 @@ def getCcdKeyName(dataid):
       the different amps/ccds in the same exposure.  This function looks
       through the reference dataId to locate a field that could be the one.
     """
-    possibleCcdFieldNames = ['ccd', 'ccdnum', 'camcol']
+    possibleCcdFieldNames = ['ccd', 'ccdnum', 'camcol', 'sensor']
 
     for name in possibleCcdFieldNames:
         if name in dataid:
             return name
     else:
         return 'ccd'
+
+
+def raftSensorToInt(vId):
+    """Construct an int that encodes raft, sensor coordinates.
+
+    >>> vId = {'filter': 'y', 'raft': '2,2', 'sensor': '1,2', 'visit': 307}
+    >>> raftSensorToInt(vId)
+    2212
+    """
+    def pair_to_int(tuple_string):
+        x, y = tuple_string.split(',')
+        return 10 * int(x) + 1 * int(y)
+
+    raft_int = pair_to_int(vId['raft'])
+    sensor_int = pair_to_int(vId['sensor'])
+    return 100*raft_int + sensor_int
 
 
 def repoNameToPrefix(repo):


### PR DESCRIPTION
This is a bit of a hack to allow `validate_drp` to run on `obs_lsstSim` and any other cameras that designate detectors with, e.g., 'raft=(0,1), sensor=(0,2)' instead of a ccd or ccnum.

Uses a new `raftSensorToInt` function in `util` to add a 'raft_sensor_int'
entry to the visit Ids while being processed in `matchreduce.py`.

Takes raft=(0,1), sensor=(0,2) -> 1002

This ID can then be used by multimatch, which requires ints
for the dataId keys used in its indexing.