### PR TITLE
DM-14869: Verify ellipticity definition choice in validate_drp

### DIFF
--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -92,7 +92,7 @@ def ellipticity(I_xx, I_xy, I_yy):
     e, e1, e2 : (float, float, float) or (numpy.array, numpy.array, numpy.array)
         Complex ellipticity, real component, imaginary component
     """
-    e = (I_xx - I_yy + 2j*I_xy) / (I_xx + I_yy + 2*SM.sqrt(I_xx*I_yy - I_xy*2))
+    e = (I_xx - I_yy + 2j*I_xy) / (I_xx + I_yy)
     e1 = np.real(e)
     e2 = np.imag(e)
     return e, e1, e2

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -57,7 +57,7 @@ class UtilCalculations(lsst.utils.tests.TestCase):
         """Is util.ellipticity correct for a diagonal line."""
 
         Ixx, Ixy, Iyy = 1, 1, 1
-        exp_e, exp_e1, exp_e2 = 0.5+0.5j, 0.5, 0.5
+        exp_e, exp_e1, exp_e2 = 0+1j, 0, 1
 
         obs_e, obs_e1, obs_e2 = util.ellipticity(Ixx, Ixy, Iyy)
         print(obs_e, obs_e1, obs_e2)
@@ -80,7 +80,7 @@ class UtilCalculations(lsst.utils.tests.TestCase):
         """Is util.ellipticity correct for an ellipse."""
 
         Ixx, Ixy, Iyy = 4, 0, 1
-        exp_e, exp_e1, exp_e2 = 1/3+0j, 1/3, 0
+        exp_e, exp_e1, exp_e2 = 0.6+0j, 0.6, 0
 
         obs_e, obs_e1, obs_e2 = util.ellipticity(Ixx, Ixy, Iyy)
         self.assertFloatsAlmostEqual(exp_e, obs_e)


### PR DESCRIPTION
Change the ellipticity calculation from second moments to use the "distortion" ellipticity convention, which matches the SRD specification, as oppose to the "shear" convention. 

See https://jira.lsstcorp.org/browse/DM-14869