### PR TITLE
Add 'detector' to list of possible 'CCD' names.

### DIFF
--- a/python/lsst/validate/drp/util.py
+++ b/python/lsst/validate/drp/util.py
@@ -342,7 +342,7 @@ def getCcdKeyName(dataid):
       the different amps/ccds in the same exposure.  This function looks
       through the reference dataId to locate a field that could be the one.
     """
-    possibleCcdFieldNames = ['ccd', 'ccdnum', 'camcol', 'sensor']
+    possibleCcdFieldNames = ['detector', 'ccd', 'ccdnum', 'camcol', 'sensor']
 
     for name in possibleCcdFieldNames:
         if name in dataid:


### PR DESCRIPTION
Trivial one-line change to add `detector`.