### PR TITLE
DM-18638: Check for at least 2 visits in AMx calc

### DIFF
--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -208,7 +208,8 @@ def calcRmsDistances(groupView, annulus, magRange, verbose=False):
                 continue
 
             finiteEntries, = np.where(np.isfinite(distances))
-            if len(finiteEntries) > 0:
+            # Need at least 2 distances to get a nonzero stdev
+            if len(finiteEntries) > 1:
                 rmsDist = np.std(np.array(distances)[finiteEntries])
                 rmsDistances.append(rmsDist)
 


### PR DESCRIPTION
before including a pair's distance stdev. The distance of a pair that
appears in only one visit has a std of zero, biasing the median RMS
if used.