### PR TITLE
DM-18754: set matplotlib backend to avoid test failures

### DIFF
--- a/tests/SConscript
+++ b/tests/SConscript
@@ -6,5 +6,5 @@ from lsst.sconsUtils import scripts, env
 scripts.BasicSConscript.tests(pyList=[])
 
 # avoid the classic matplotlib "Invalid DISPLAY variable" error
-if platform.system() == "Linux":
-    env["ENV"]["MPLBACKEND"] = "Agg"
+# note this will not help if one runs the tests from the command line with pytest
+env["ENV"]["MPLBACKEND"] = "Agg"


### PR DESCRIPTION
There is apparently a bug in `matplotlib` that causes tests to fail in `validate_drp` if the default backend is used.  This has been seen on linux in the past, but now is seen on macOS as of mojave.  This PR sets the backend to `Agg` regardless of the architecture being run.