### PR TITLE
Use sample standard deviation for AMx.

### DIFF
--- a/python/lsst/validate/drp/calcsrd/amx.py
+++ b/python/lsst/validate/drp/calcsrd/amx.py
@@ -208,9 +208,10 @@ def calcRmsDistances(groupView, annulus, magRange, verbose=False):
                 continue
 
             finiteEntries, = np.where(np.isfinite(distances))
-            # Need at least 2 distances to get a nonzero stdev
+            # Need at least 2 distances to get a finite sample stdev
             if len(finiteEntries) > 1:
-                rmsDist = np.std(np.array(distances)[finiteEntries])
+                # ddof=1 to get sample standard deviation (e.g., 1/(n-1))
+                rmsDist = np.std(np.array(distances)[finiteEntries], ddof=1)
                 rmsDistances.append(rmsDist)
 
     # return quantity


### PR DESCRIPTION
Use 1/(n-1) instead of 1/n to define standdard deviation.
Multiplies `np.std`, which is `1/n` by `n/n-1`.

Passes Jenkins.