### PR TITLE
DM-21950: Update validate_drp to work with different external calibrations

### DIFF
--- a/python/lsst/validate/drp/matchedVisitMetricsTask.py
+++ b/python/lsst/validate/drp/matchedVisitMetricsTask.py
@@ -71,9 +71,24 @@ class MatchedVisitMetricsConfig(Config):
         dtype=float, default=1.0,
         doc="Match radius (arcseconds)."
     )
-    useJointCal = Field(
+    doApplyExternalPhotoCalib = Field(
         dtype=bool, default=False,
-        doc="Whether to use jointcal (or meas_mosaic) to calibrate measurements"
+        doc="Whether to apply external photometric calibration (PhotoCalib)"
+    )
+    externalPhotoCalibName = Field(
+        dtype=str,
+        doc=("Type of external PhotoCalib.  Currently supported are jointcal, "
+             "fgcm, and fgcm_tract."),
+        default="jointcal"
+    )
+    doApplyExternalWcs = Field(
+        dtype=bool, default=False,
+        doc="Whether to apply external astrometric calibration (wcs)"
+    )
+    externalWcsName = Field(
+        dtype=str,
+        doc="Type of external wcs.  Currently supported is jointcal.",
+        default="jointcal"
     )
     skipTEx = Field(
         dtype=bool, default=False,
@@ -98,12 +113,14 @@ class MatchedVisitMetricsTask(CmdLineTask):
 
     The input data IDs passed via the `--id` argument should contain the same
     keys as the `wcs` dataset (those used by the `calexp` dataset plus
-    `tract`).  When `config.useJointCal` is `True`, the `photoCalib` and `wcs`
-    datasets are used to calibrate sources; when it is `False`, `tract` is
-    ignored (but must still be present) and the photometric calibration is
-    retrieved from the `calexp` and the sky positions of sources are loaded
-    directly from the `src` dataset (which is used to obtain raw measurmenets
-    in both cases).
+    `tract`).  When `config.doApplyExternalPhotoCalib` is `True`, the
+    photometric calibration (`photoCalib`) is taken from
+    `config.externalPhotoCalibName`.  Otherwise, the photometric calibration
+    is retrieved from the `calexp`. When `config.doApplyExternalWcs` is
+    `True`, the astrometric calibration (`wcs`) is taken from
+    `config.externalWcsName`.  Otherwise, the astrometric calbration is
+    unchanged from the positions loaded from the `src` dataset.  In all cases
+    the `tract` must be present.
     """
 
     _DefaultName = "matchedVisitMetrics"
@@ -128,7 +145,10 @@ class MatchedVisitMetricsTask(CmdLineTask):
                            makeJson=self.config.makeJson,
                            filterName=filterName,
                            outputPrefix=output_prefix,
-                           useJointCal=self.config.useJointCal,
+                           doApplyExternalPhotoCalib=self.config.doApplyExternalPhotoCalib,
+                           externalPhotoCalibName=self.config.externalPhotoCalibName,
+                           doApplyExternalWcs=self.config.doApplyExternalWcs,
+                           externalWcsName=self.config.externalWcsName,
                            skipTEx=self.config.skipTEx,
                            verbose=self.config.verbose,
                            metrics_package=self.config.metricsRepository,

--- a/python/lsst/validate/drp/validate.py
+++ b/python/lsst/validate/drp/validate.py
@@ -181,8 +181,8 @@ def runOneRepo(repo, dataIds=None, metrics=None, outputPrefix='', verbose=False,
     dataIds : `list` of `dict`
         List of butler data IDs of Image catalogs to compare to reference.
         The calexp cpixel image is needed for the photometric calibration.
-        Tract IDs must be included if doApplyExternalPhotoCalib or
-        doApplyExternalWcs is True.
+        Tract IDs must be included if "doApplyExternalPhotoCalib" or
+        "doApplyExternalSkyWcs" is True.
     metrics : `dict` or `collections.OrderedDict`
         Dictionary of `lsst.validate.base.Metric` instances. Typically this is
         data from ``validate_drp``\ 's ``metrics.yaml`` and loaded with
@@ -251,7 +251,7 @@ def runOneRepo(repo, dataIds=None, metrics=None, outputPrefix='', verbose=False,
 def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
                  makeJson=True, filterName=None, outputPrefix='',
                  doApplyExternalPhotoCalib=False, externalPhotoCalibName=None,
-                 doApplyExternalWcs=False, externalWcsName=None,
+                 doApplyExternalSkyWcs=False, externalSkyWcsName=None,
                  skipTEx=False, verbose=False,
                  metrics_package='verify_metrics',
                  instrument='Unknown', dataset_repo_url='./',
@@ -288,30 +288,34 @@ def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
         Name of the filter (bandpass).
     doApplyExternalPhotoCalib : bool, optional
         Apply external photoCalib to calibrate fluxes.
-        Default is False.
     externalPhotoCalibName : str, optional
         Type of external `PhotoCalib` to apply.  Currently supported are jointcal,
         fgcm, and fgcm_tract.  Must be set if doApplyExternalPhotoCalib is True.
-        Default is None.
-    doApplyExternalWcs : bool, optional
+    doApplyExternalSkyWcs : bool, optional
         Apply external wcs to calibrate positions.
-        Default is False.
-    externalWcsName : str, optional
+    externalSkyWcsName : str, optional
         Type of external `wcs` to apply.  Currently supported is jointcal.
-        Must be set if doApplyExternalWcs is True.  Default is None.
+        Must be set if "doApplyExternalSkyWcs" is True.
     skipTEx : bool, optional
         Skip TEx calculations (useful for older catalogs that don't have
         PsfShape measurements).
     verbose : bool, optional
         Output additional information on the analysis steps.
     skipNonSrd : bool, optional
-        Skip any metrics not defined in the LSST SRD; default False.
+        Skip any metrics not defined in the LSST SRD.
+
+    Raises
+    ------
+    RuntimeError:
+        Raised if "doApplyExternalPhotoCalib" is True and "externalPhotoCalibName"
+        is None, or if "doApplyExternalSkyWcs" is True and "externalSkyWcsName" is
+        None.
     """
 
     if doApplyExternalPhotoCalib and externalPhotoCalibName is None:
         raise RuntimeError("Must set externalPhotoCalibName if doApplyExternalPhotoCalib is True.")
-    if doApplyExternalWcs and externalWcsName is None:
-        raise RuntimeError("Must set externalWcsName if doApplyExternalWcs is True.")
+    if doApplyExternalSkyWcs and externalSkyWcsName is None:
+        raise RuntimeError("Must set externalSkyWcsName if doApplyExternalSkyWcs is True.")
 
     job = Job.load_metrics_package(meta={'instrument': instrument,
                                          'filter_name': filterName,
@@ -322,8 +326,8 @@ def runOneFilter(repo, visitDataIds, metrics, brightSnr=100,
     matchedDataset = build_matched_dataset(repo, visitDataIds,
                                            doApplyExternalPhotoCalib=doApplyExternalPhotoCalib,
                                            externalPhotoCalibName=externalPhotoCalibName,
-                                           doApplyExternalWcs=doApplyExternalWcs,
-                                           externalWcsName=externalWcsName,
+                                           doApplyExternalSkyWcs=doApplyExternalSkyWcs,
+                                           externalSkyWcsName=externalSkyWcsName,
                                            skipTEx=skipTEx, skipNonSrd=skipNonSrd)
 
     photomModel = build_photometric_error_model(matchedDataset)


### PR DESCRIPTION
Update validate_drp so that external photometric and astrometric corrections are separated, and so that fgcmcal can be used in place of jointcal for photometry.