### PR TITLE
Add disableCc=True to SConstruct.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,3 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
-scripts.BasicSConstruct("validate_drp")
+scripts.BasicSConstruct("validate_drp", disableCc=True)


### PR DESCRIPTION
This is a pure-Python package that doesn't need to compile any C++.